### PR TITLE
Fix folder listing crash caused by orphaned subfolder references

### DIFF
--- a/src/memo_helpers/list_folder.py
+++ b/src/memo_helpers/list_folder.py
@@ -1,42 +1,67 @@
 import subprocess
 import click
 
+FOLDER_SEPARATOR = "|||"
+
+
+def _build_tree(folders_with_parents):
+    """Build a folder tree from a flat list of (name, parent) tuples."""
+    children = {}
+    for name, parent in folders_with_parents:
+        children.setdefault(parent, []).append(name)
+    return children
+
+
+def _render_tree(children, parent="", indent=0):
+    """Render the folder tree as indented text."""
+    lines = []
+    for name in children.get(parent, []):
+        lines.append(" " * indent + name)
+        if name in children:
+            lines.extend(_render_tree(children, name, indent + 2))
+    return lines
+
 
 def notes_folders():
-    script = """
+    script = f"""
     tell application "Notes"
-    set topLevelFolders to every folder
-    set folderHierarchy to my listFolders(topLevelFolders, 0)
-    return folderHierarchy
+    set output to ""
+    repeat with f in every folder
+        set fName to name of f
+        try
+            set c to container of f
+            set cClass to class of c as text
+            if cClass is "folder" then
+                set parentName to name of c
+            else
+                set parentName to ""
+            end if
+        on error
+            set parentName to ""
+        end try
+        set output to output & fName & "{FOLDER_SEPARATOR}" & parentName & linefeed
+    end repeat
+    return output
     end tell
-    on listFolders(folders, indentLevel)
-    set hierarchyText to ""
-    set rootFolders to folders
-    repeat with f in rootFolders
-        set folderName to name of f
-        set indent to my repeatChar(" ", indentLevel)
-        set hierarchyText to hierarchyText & indent & folderName & return
-        set subFolders to folder of f
-        set xcount to count subFolders
-        if xcount > 0 then
-            set hierarchyText to hierarchyText & my listFolders(subFolders, indentLevel + 2)
-        end if
-    end repeat
-    return hierarchyText
-    end listFolders
-    on repeatChar(theChar, xcount)
-    set theString to ""
-    repeat xcount times
-        set theString to theString & theChar
-    end repeat
-    return theString
-    end repeatChar
     """
 
     try:
         result = subprocess.run(
             ["osascript", "-e", script], capture_output=True, text=True, check=True
         )
-        return result.stdout.strip()
+        raw = result.stdout.strip()
+        if not raw:
+            return ""
+
+        folders_with_parents = []
+        for line in raw.split("\n"):
+            if FOLDER_SEPARATOR in line:
+                name, parent = line.split(FOLDER_SEPARATOR, 1)
+                folders_with_parents.append((name.strip(), parent.strip()))
+
+        children = _build_tree(folders_with_parents)
+        lines = _render_tree(children)
+        return "\n".join(lines)
     except subprocess.CalledProcessError as e:
         click.echo(f"Error running AppleScript: {e}")
+        return ""


### PR DESCRIPTION
## Problem

`memo notes` and `memo notes -fl` crash on macOS when listing folders:

```
TypeError: argument of type 'NoneType' is not iterable
```

**Root cause:** The `folder of f` AppleScript call in `notes_folders()` can return stale/orphaned folder references from the Notes CoreData database. These are left behind when subfolders are deleted through the Apple Notes UI - they're invisible in the UI but AppleScript still returns them. When the recursive handler tries to access properties like `name of f` on these ghost references, it crashes with:

```
execution error: Notes got an error: Can't get folder id "x-coredata://...ICFolder/p900". (-1728)
```

Since `notes_folders()` doesn't return a value in the `except` block, it returns `None`, which then crashes `memo.py` at `if folder not in folders`.

**How to reproduce:**
1. In Apple Notes, create a folder with a subfolder inside it
2. Delete the subfolder
3. Run `memo notes -fl`

## Fix

Replace the recursive AppleScript with a single-pass query that fetches each folder's name and parent container in one Apple Events call, then builds the hierarchy tree in Python.

This fixes three issues:

- **Ghost folder references crash the recursive enumeration** - `folder of f` returns stale references from deleted subfolders. The new approach uses `container of f` (child-to-parent) instead, which only accesses properties on folders that `every folder` successfully resolved
- **No error handling around folder access** - the new AppleScript uses `try/on error` around container access for robustness
- **Missing return value on error** - the `except` block in `notes_folders()` didn't return a value, causing `None` to propagate to callers

## Before / After

**Before:** Every `memo notes` command crashes with TypeError

**After:** `memo notes -fl` shows proper hierarchy:
```
Archive
  Work
    People
    Projects
      Delivery
        POC
Areas
  Planning
  Health
    Fitness
Resources
  Books & Notes
    GTD
```

## Testing

Verified by installing from upstream `main` (crashes) and from this branch (works) via `pipx install . --python python3.13` on macOS with ~100 folders including nested subfolders.
