### PR TITLE
feat: add --view/-v flag to read note content

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 ## :sparkles: Features
 
 :heavy_check_mark: View your notes and reminders directly from the terminal\
+:heavy_check_mark: Read the full content of a note as clean Markdown from the terminal\
 :heavy_check_mark: Edit your notes and reminders right from the terminal\
 :heavy_check_mark: Add new notes and reminders effortlessly through the terminal\
 :heavy_check_mark: Move notes to another folder effortlessly through the terminal\
@@ -120,6 +121,7 @@ Options:
   -s, --search       Fuzzy search your notes.
   -r, --remove       Remove the folder you specified.
   -ex, --export      Export your notes to the Desktop.
+  -v, --view INTEGER Display the content of note N from the list.
   --help             Show this message and exit.
 ```
 

--- a/src/memo_helpers/validation_memo.py
+++ b/src/memo_helpers/validation_memo.py
@@ -2,7 +2,7 @@ import click
 
 
 def selection_notes_validation(
-    folder, edit, delete, move, add, flist, search, remove, export
+    folder, edit, delete, move, add, flist, search, remove, export, view
 ):
     used_flags = {
         "folder": bool(folder),
@@ -14,6 +14,7 @@ def selection_notes_validation(
         "search": search,
         "remove": remove,
         "export": export,
+        "view": view is not None,
     }
 
     if add and not folder:
@@ -26,9 +27,9 @@ def selection_notes_validation(
             "--flist must be used alone. It cannot be combined with other flags or --folder."
         )
 
-    modifier_flags = ["edit", "delete", "move", "remove", "search", "export"]
+    modifier_flags = ["edit", "delete", "move", "remove", "search", "export", "view"]
     used_modifiers = [f for f in modifier_flags if used_flags[f]]
     if len(used_modifiers) > 1:
         raise click.UsageError(
-            "Only one of --edit, --delete, --move, --remove , --export or search can be used at a time."
+            "Only one of --edit, --delete, --move, --remove, --export, --view, or --search can be used at a time."
         )

--- a/test/memo_notes_test.py
+++ b/test/memo_notes_test.py
@@ -70,3 +70,23 @@ def test_notes_flist():
     result = runner.invoke(cli, ["notes", "--flist"])
     assert result.exit_code == 0
     assert "Folders and subfolders in Notes:" in result.output
+
+
+def test_notes_view():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "--view", "1"])
+    assert result.exit_code == 0
+
+
+def test_notes_view_invalid():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "--view", "99999"])
+    assert result.exit_code == 0
+    assert "not found" in result.output
+
+
+def test_notes_view_combined_with_edit():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "--view", "1", "--edit"])
+    assert result.exit_code == 2
+    assert "Only one of" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 
 [[package]]
 name = "memo"
-version = "0.3.2"
+version = "0.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
## Summary

- Add `--view`/`-v` option to `memo notes` to print a note's body as clean Markdown
- Useful for scripting and agent-based workflows (e.g. OpenClaw) where interactive editing is not available
- `--view` is mutually exclusive with all other action flags (`--edit`, `--delete`, `--move`, `--remove`, `--export`, `--search`)

## Usage

```bash
memo notes           # list all notes with numbers
memo notes --view 3  # print note #3 as Markdown
memo notes -v 3      # short form
```

## Files changed

- `src/memo/memo.py` — added `--view/-v` option; fetches note body via AppleScript, converts HTML to Markdown, prints to stdout  
- `src/memo_helpers/validation_memo.py` — added `view` to `used_flags` and `modifier_flags`  
- `test/memo_notes_test.py` — added tests for happy path, invalid note number, and flag conflict  
- `README.md` — updated Features list and `--help` block  
- `uv.lock` — refreshed to match version declared in `pyproject.toml`  

---

## Test plan

- `memo notes` lists notes with numbers  
- `memo notes --view 1` prints the first note's content as Markdown  
- `memo notes --view 99999` prints: `Note 99999 not found.`  
- `memo notes --view 1 --edit` exits with a usage error  
- `pytest test/memo_notes_test.py` passes  