### PR TITLE
API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@
 :heavy_check_mark: Add new notes and reminders effortlessly through the terminal\
 :heavy_check_mark: Move notes to another folder effortlessly through the terminal\
 :heavy_check_mark: Mark reminders as completed from the terminal\
-:heavy_check_mark: Export your notes to HTML and convert them to Markdown
+:heavy_check_mark: Export your notes to HTML and convert them to Markdown\
+:heavy_check_mark: Notes API for non-interactive use (scripts, agents)
 
 ## :rocket: Technologies
 
@@ -105,24 +106,57 @@ Use the command `memo notes --help` to see all the options available for notes.
 
 ```bash
 memo notes --help
-Usage: memo notes [OPTIONS]
+Usage: memo notes [OPTIONS] COMMAND [ARGS]...
 
 Options:
-  -f, --folder TEXT  Specify a folder to filter the notes (leave empty to get
-                     all).
-  -a, --add          Add a note to the specified folder. Specify a folder
-                     using the --folder flag.
-  -e, --edit         Edit a note in the specified folder. Specify a folder
-                     using the --folder flag.
-  -d, --delete       Delete a note in the specified folder. Specify a folder
-                     using the --folder flag.
-  -m, --move         Move a note to a different folder.
-  -fl, --flist       List all the folders and subfolders.
-  -s, --search       Fuzzy search your notes.
-  -r, --remove       Remove the folder you specified.
-  -ex, --export      Export your notes to the Desktop.
-  -v, --view INTEGER Display the content of note N from the list.
-  --help             Show this message and exit.
+  -f, --folder TEXT   Specify a folder to filter the notes (leave empty to get all).
+  -a, --add           Add a note to the specified folder.
+  -e, --edit          Edit a note in the specified folder.
+  -d, --delete        Delete a note in the specified folder.
+  -m, --move          Move a note to a different folder.
+  -fl, --flist        List all the folders and subfolders.
+  -s, --search        Fuzzy search your notes.
+  -r, --remove        Remove the folder you specified.
+  -ex, --export       Export your notes to the Desktop.
+  -nc, --no-cache     Bypass the notes cache and fetch fresh data.
+  -v, --view INTEGER  Display the content of note N from the list.
+  --help              Show this message and exit.
+
+Commands:
+  api  Machine-friendly API for notes (non-interactive).
+```
+
+### Notes API (for agents)
+
+The `memo notes api` subcommand provides non-interactive, machine-friendly operations for scripts and AI agents. Output is plain text, well-parsable, with no prompts or colored messages. Use `memo notes api --help` for full details.
+
+```bash
+memo notes api list [--folder FOLDER] [--format tsv|lines|json]
+memo notes api show <note-id>
+memo notes api edit <note-id>          # reads from stdin
+memo notes api add --folder FOLDER     # reads from stdin
+memo notes api delete <note-id>
+memo notes api move <note-id> <target-folder>
+memo notes api folders [--format tsv|lines|json]
+memo notes api search <query> [--folder FOLDER] [--body]
+memo notes api remove <folder-path> --force
+memo notes api export --path PATH [--markdown]
+```
+
+Examples:
+
+```bash
+# List notes in a folder (TSV: id, folder, title)
+memo notes api list -f "Work"
+
+# Show note content as Markdown
+memo notes api show x-coredata://.../ICNote/p123
+
+# Edit note from file
+memo notes api edit x-coredata://.../ICNote/p123 < note.md
+
+# Create note from stdin
+echo "# New note" | memo notes api add -f "Work"
 ```
 
 Use the command `memo rem --help` to see all the options available for reminders.
@@ -149,8 +183,8 @@ Options:
   --help     Show this message and exit.
 
 Commands:
-  notes
-  rem
+  notes  Manage Apple Notes (interactive and api subcommands).
+  rem    Manage Apple Reminders.
 ```
 
 Memo uses `$EDITOR` to edit and add notes. You can set it up by running the following command:

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -2,3 +2,4 @@ nav:
   - index.md
   - Installation.md
   - Getting started.md
+  - Notes-API.md

--- a/docs/Notes-API.md
+++ b/docs/Notes-API.md
@@ -1,0 +1,59 @@
+# Notes API (for agents)
+
+The `memo notes api` subcommand provides non-interactive, machine-friendly operations for scripts and AI agents. All commands:
+
+- Bypass the notes cache (fresh data every time)
+- Output plain text in well-parsable formats
+- Use no prompts, colored messages, or interactive dialogs
+- Support stable note IDs from Apple Notes
+
+Run `memo notes api --help` for the full command list.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `list` | List notes with id, folder, title (TSV, lines, or JSON) |
+| `show` | Output note body as Markdown |
+| `edit` | Replace note body from stdin |
+| `add` | Create note from stdin |
+| `delete` | Delete a note by ID |
+| `move` | Move note to another folder |
+| `folders` | List folders and subfolders |
+| `search` | Search notes by substring match |
+| `remove` | Delete a folder (requires `--force`) |
+| `export` | Export all notes to a directory |
+
+## Output formats
+
+For `list`, `folders`, and `search`:
+
+- `tsv` (default): Tab-separated values
+- `lines`: Pipe-separated (`id|folder|title`)
+- `json`: NDJSON, one object per line
+
+## Examples
+
+```bash
+# List notes in folder
+memo notes api list -f "Work"
+
+# List with JSON output
+memo notes api list --format json
+
+# Show note content
+memo notes api show x-coredata://.../ICNote/p123
+
+# Edit note from file
+memo notes api edit x-coredata://.../ICNote/p123 < note.md
+
+# Create note
+echo "# Title" | memo notes api add -f "Work"
+
+# Search notes
+memo notes api search "meeting" --body
+```
+
+## Stdin behavior
+
+`edit` and `add` read content from stdin when it is not a TTY (e.g. pipe or redirect). When run interactively with no input, they exit with an error.

--- a/src/memo/memo.py
+++ b/src/memo/memo.py
@@ -21,6 +21,8 @@ from memo_helpers.id_search_memo import id_search_memo
 from memo_helpers.md_converter import md_converter
 from memo_helpers.api_memo import (
     list_notes,
+    list_folders,
+    search_notes,
     show_note,
     edit_note_stdin,
     add_note_stdin,
@@ -269,6 +271,83 @@ def api_add(folder):
     ok, err = add_note_stdin(folder, content)
     if not ok:
         click.echo(err or "Failed to create note.", err=True)
+        raise SystemExit(3)
+
+
+@api.command("delete")
+@click.argument("note_id")
+def api_delete(note_id):
+    """Delete a note by ID."""
+    ok, err = delete_note(note_id, quiet=True)
+    if not ok:
+        click.echo(err or "Failed to delete note.", err=True)
+        raise SystemExit(3)
+
+
+@api.command("move")
+@click.argument("note_id")
+@click.argument("target_folder")
+def api_move(note_id, target_folder):
+    """Move a note to another folder."""
+    ok, err = move_note(note_id, target_folder, quiet=True)
+    if not ok:
+        click.echo(err or "Failed to move note.", err=True)
+        raise SystemExit(3)
+
+
+@api.command("folders")
+@click.option(
+    "--format",
+    type=click.Choice(["tsv", "lines", "json"]),
+    default="tsv",
+    help="Output format.",
+)
+def api_folders(format):
+    """List folders and subfolders in parsable format."""
+    output = list_folders(format=format)
+    if output:
+        click.echo(output)
+
+
+@api.command("search")
+@click.argument("query")
+@click.option("--folder", "-f", default="", help="Filter by folder.")
+@click.option(
+    "--format",
+    type=click.Choice(["tsv", "lines", "json"]),
+    default="tsv",
+    help="Output format.",
+)
+@click.option("--body", is_flag=True, help="Also search note body.")
+def api_search(query, folder, format, body):
+    """Search notes by substring match."""
+    output = search_notes(query, folder, format, search_body=body)
+    if output:
+        click.echo(output)
+
+
+@api.command("remove")
+@click.argument("folder_path", nargs=-1, required=True)
+@click.option("--force", is_flag=True, required=True, help="Required to confirm deletion.")
+def api_remove(folder_path, force):
+    """Delete a folder and all notes in it."""
+    folder_path = " ".join(folder_path)
+    ok, err = delete_note_folder(folder_path, quiet=True)
+    if not ok:
+        click.echo(err or "Failed to remove folder.", err=True)
+        raise SystemExit(3)
+
+
+@api.command("export")
+@click.option("--path", "-p", "export_path", required=True, help="Export directory.")
+@click.option("--markdown", is_flag=True, help="Convert to Markdown after export.")
+def api_export(export_path, markdown):
+    """Export all notes to a directory."""
+    if not os.path.exists(export_path):
+        os.makedirs(export_path, exist_ok=True)
+    ok, err = export_memo(export_path, quiet=True, to_markdown=markdown)
+    if not ok:
+        click.echo(err or "Failed to export.", err=True)
         raise SystemExit(3)
 
 

--- a/src/memo/memo.py
+++ b/src/memo/memo.py
@@ -19,6 +19,7 @@ from memo_helpers.cache_memo import clear_cache
 from memo_helpers.export_memo import export_memo
 from memo_helpers.id_search_memo import id_search_memo
 from memo_helpers.md_converter import md_converter
+from memo_helpers.api_memo import list_notes
 
 # TODO: Check if notes can be imported.
 # TODO: Check if its possible to fetch .localized names from the folders.
@@ -203,6 +204,26 @@ def notes(
 def api():
     """Machine-friendly API for notes (non-interactive)."""
     pass
+
+
+@api.command("list")
+@click.option(
+    "--folder",
+    "-f",
+    default="",
+    help="Filter notes by folder (prefix match).",
+)
+@click.option(
+    "--format",
+    type=click.Choice(["tsv", "lines", "json"]),
+    default="tsv",
+    help="Output format.",
+)
+def api_list(folder, format):
+    """List notes with stable IDs and titles (no cache)."""
+    output = list_notes(folder=folder, format=format)
+    if output:
+        click.echo(output)
 
 
 @cli.command()

--- a/src/memo/memo.py
+++ b/src/memo/memo.py
@@ -19,7 +19,13 @@ from memo_helpers.cache_memo import clear_cache
 from memo_helpers.export_memo import export_memo
 from memo_helpers.id_search_memo import id_search_memo
 from memo_helpers.md_converter import md_converter
-from memo_helpers.api_memo import list_notes
+from memo_helpers.api_memo import (
+    list_notes,
+    show_note,
+    edit_note_stdin,
+    add_note_stdin,
+    _read_stdin_content,
+)
 
 # TODO: Check if notes can be imported.
 # TODO: Check if its possible to fetch .localized names from the folders.
@@ -224,6 +230,46 @@ def api_list(folder, format):
     output = list_notes(folder=folder, format=format)
     if output:
         click.echo(output)
+
+
+@api.command("show")
+@click.argument("note_id")
+def api_show(note_id):
+    """Output note body as Markdown."""
+    content, err = show_note(note_id)
+    if content is not None:
+        click.echo(content)
+    else:
+        click.echo(err or "Note not found.", err=True)
+        raise SystemExit(2)
+
+
+@api.command("edit")
+@click.argument("note_id")
+def api_edit(note_id):
+    """Replace note body with content from stdin."""
+    content = _read_stdin_content()
+    if content is None:
+        click.echo("No input provided. Pipe content or redirect from a file.", err=True)
+        raise SystemExit(1)
+    ok, err = edit_note_stdin(note_id, content)
+    if not ok:
+        click.echo(err or "Failed to update note.", err=True)
+        raise SystemExit(3)
+
+
+@api.command("add")
+@click.option("--folder", "-f", required=True, help="Folder to create note in.")
+def api_add(folder):
+    """Create a note from stdin."""
+    content = _read_stdin_content()
+    if content is None:
+        click.echo("No input provided. Pipe content or redirect from a file.", err=True)
+        raise SystemExit(1)
+    ok, err = add_note_stdin(folder, content)
+    if not ok:
+        click.echo(err or "Failed to create note.", err=True)
+        raise SystemExit(3)
 
 
 @cli.command()

--- a/src/memo/memo.py
+++ b/src/memo/memo.py
@@ -31,7 +31,7 @@ def cli():
     pass
 
 
-@cli.command()
+@cli.group(invoke_without_command=True)
 @click.option(
     "--folder",
     "-f",
@@ -94,9 +94,12 @@ def cli():
     default=None,
     help="Display the content of note N from the list.",
 )
+@click.pass_context
 def notes(
-    folder, edit, add, delete, move, flist, search, remove, export, view, no_cache
+    ctx, folder, edit, add, delete, move, flist, search, remove, export, view, no_cache
 ):
+    if ctx.invoked_subcommand is not None:
+        return
     selection_notes_validation(
         folder, edit, delete, move, add, flist, search, remove, export, view
     )
@@ -194,6 +197,12 @@ def notes(
                     return
 
             export_memo(export_path)
+
+
+@notes.group()
+def api():
+    """Machine-friendly API for notes (non-interactive)."""
+    pass
 
 
 @cli.command()

--- a/src/memo_helpers/api_memo.py
+++ b/src/memo_helpers/api_memo.py
@@ -1,0 +1,35 @@
+"""Machine-friendly API for notes (non-interactive)."""
+
+from memo_helpers.get_memo import get_note
+
+
+def list_notes(folder="", format="tsv"):
+    """Fetch notes without cache and return formatted output."""
+    note_map, notes_list = get_note(use_cache=False)
+    notes_list_filter = [
+        note for note in enumerate(notes_list, start=1) if folder in note[1]
+    ]
+    lines = []
+    seen_id = set()
+    for idx, note_title in notes_list_filter:
+        note_data = note_map.get(idx)
+        if note_data is None:
+            continue
+        note_id, full_title = note_data
+        if note_id in seen_id:
+            continue
+        seen_id.add(note_id)
+        if " - " in full_title:
+            folder_name, title = full_title.split(" - ", 1)
+        else:
+            folder_name, title = "", full_title
+        if format == "tsv":
+            lines.append(f"{note_id}\t{folder_name}\t{title}")
+        elif format == "lines":
+            lines.append(f"{note_id}|{folder_name}|{title}")
+        elif format == "json":
+            import json
+            lines.append(
+                json.dumps({"id": note_id, "folder": folder_name, "title": title})
+            )
+    return "\n".join(lines)

--- a/src/memo_helpers/api_memo.py
+++ b/src/memo_helpers/api_memo.py
@@ -1,6 +1,49 @@
 """Machine-friendly API for notes (non-interactive)."""
 
+import json
+import os
+import re
+import sys
+import tempfile
+import subprocess
+import mistune
+
 from memo_helpers.get_memo import get_note
+from memo_helpers.id_search_memo import id_search_memo
+from memo_helpers.md_converter import md_converter
+
+
+def _read_stdin_content():
+    """Read content from stdin. Returns None if stdin is a TTY (no input)."""
+    if sys.stdin.isatty():
+        return None
+    return sys.stdin.read()
+
+
+def _update_note_body(note_id, html_content):
+    """Update note body via temp file to avoid AppleScript escaping issues."""
+    fd, path = tempfile.mkstemp(suffix=".html")
+    try:
+        os.write(fd, html_content.encode("utf-8"))
+        os.close(fd)
+        escaped_path = path.replace("\\", "\\\\").replace('"', '\\"')
+        script = f'''
+        set htmlPath to "{escaped_path}"
+        set htmlContent to do shell script "cat " & quoted form of htmlPath
+        tell application "Notes"
+            set n to first note whose id is "{note_id}"
+            set body of n to htmlContent
+        end tell
+        '''
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode == 0, result.stderr
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
 
 
 def list_notes(folder="", format="tsv"):
@@ -28,8 +71,53 @@ def list_notes(folder="", format="tsv"):
         elif format == "lines":
             lines.append(f"{note_id}|{folder_name}|{title}")
         elif format == "json":
-            import json
             lines.append(
                 json.dumps({"id": note_id, "folder": folder_name, "title": title})
             )
     return "\n".join(lines)
+
+
+def show_note(note_id):
+    """Fetch note body and return as Markdown."""
+    result = id_search_memo(note_id)
+    if result.returncode != 0:
+        return None, result.stderr
+    markdown_content = md_converter(result)[0]
+    return markdown_content, None
+
+
+def edit_note_stdin(note_id, content):
+    """Replace note body with content (Markdown). Strips image placeholders."""
+    for placeholder in re.findall(r"\[MEMO_IMG_\d+\]", content):
+        content = content.replace(placeholder, "")
+    html_content = mistune.markdown(content)
+    return _update_note_body(note_id, html_content)
+
+
+def add_note_stdin(folder_name, content):
+    """Create note from Markdown content."""
+    html_content = mistune.markdown(content)
+    fd, path = tempfile.mkstemp(suffix=".html")
+    try:
+        os.write(fd, html_content.encode("utf-8"))
+        os.close(fd)
+        escaped_path = path.replace("\\", "\\\\").replace('"', '\\"')
+        script = f'''
+        set htmlPath to "{escaped_path}"
+        set htmlContent to do shell script "cat " & quoted form of htmlPath
+        tell application "Notes"
+            set targetFolder to first folder whose name is "{folder_name}"
+            tell targetFolder
+                make new note with properties {{body:htmlContent}}
+            end tell
+        end tell
+        '''
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode == 0, result.stderr
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)

--- a/src/memo_helpers/api_memo.py
+++ b/src/memo_helpers/api_memo.py
@@ -11,6 +11,7 @@ import mistune
 from memo_helpers.get_memo import get_note
 from memo_helpers.id_search_memo import id_search_memo
 from memo_helpers.md_converter import md_converter
+from memo_helpers.list_folder import folders_with_parents, _build_tree
 
 
 def _read_stdin_content():
@@ -44,6 +45,63 @@ def _update_note_body(note_id, html_content):
     finally:
         if os.path.exists(path):
             os.unlink(path)
+
+
+def _folder_paths(children, parent="", prefix=""):
+    """Build list of folder paths from tree."""
+    paths = []
+    for name in children.get(parent, []):
+        path = f"{prefix}{name}" if prefix else name
+        paths.append(path)
+        if name in children:
+            paths.extend(_folder_paths(children, name, f"{path}/"))
+    return paths
+
+
+def list_folders(format="tsv"):
+    """List folders and subfolders in parsable format."""
+    fwp = folders_with_parents()
+    children = _build_tree(fwp)
+    paths = _folder_paths(children)
+    if format == "json":
+        return "\n".join(json.dumps({"path": p}) for p in paths)
+    return "\n".join(paths)
+
+
+def search_notes(query, folder="", format="tsv", search_body=False):
+    """Search notes by substring match on title (and optionally body)."""
+    note_map, notes_list = get_note(use_cache=False)
+    notes_list_filter = [n for n in enumerate(notes_list, start=1) if folder in n[1]]
+    matches = []
+    query_lower = query.lower()
+    for idx, note_title in notes_list_filter:
+        note_data = note_map.get(idx)
+        if note_data is None:
+            continue
+        note_id, full_title = note_data
+        if " - " in full_title:
+            folder_name, title = full_title.split(" - ", 1)
+        else:
+            folder_name, title = "", full_title
+        if query_lower in title.lower():
+            matches.append((note_id, folder_name, title))
+        elif search_body:
+            result = id_search_memo(note_id)
+            if result.returncode == 0:
+                md = md_converter(result)[0]
+                if query_lower in md.lower():
+                    matches.append((note_id, folder_name, title))
+    lines = []
+    for note_id, folder_name, title in matches:
+        if format == "tsv":
+            lines.append(f"{note_id}\t{folder_name}\t{title}")
+        elif format == "lines":
+            lines.append(f"{note_id}|{folder_name}|{title}")
+        elif format == "json":
+            lines.append(
+                json.dumps({"id": note_id, "folder": folder_name, "title": title})
+            )
+    return "\n".join(lines)
 
 
 def list_notes(folder="", format="tsv"):

--- a/src/memo_helpers/delete_memo.py
+++ b/src/memo_helpers/delete_memo.py
@@ -2,7 +2,7 @@ import click
 import subprocess
 
 
-def delete_note(note_id):
+def delete_note(note_id, quiet=False):
     script = f'''
     tell application "Notes"
         set theNote to first note whose id is "{note_id}"
@@ -13,12 +13,15 @@ def delete_note(note_id):
     result = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
 
     if result.returncode == 0:
-        click.secho("\nNote deleted successfully.", fg="green")
+        if not quiet:
+            click.secho("\nNote deleted successfully.", fg="green")
     else:
-        click.secho(f"Error: {result.stderr}", fg="red")
+        if not quiet:
+            click.secho(f"Error: {result.stderr}", fg="red")
+    return result.returncode == 0, result.stderr
 
 
-def delete_note_folder(folder_name):
+def delete_note_folder(folder_name, quiet=False):
     script = f'''
     tell application "Notes"
         set selectedFolder to first folder whose name is "{folder_name}"
@@ -28,9 +31,12 @@ def delete_note_folder(folder_name):
     result = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
 
     if result.returncode == 0:
-        click.secho("\nFolder deleted successfully.", fg="green")
+        if not quiet:
+            click.secho("\nFolder deleted successfully.", fg="green")
     else:
-        click.secho(f"Error: {result.stderr}", fg="red")
+        if not quiet:
+            click.secho(f"Error: {result.stderr}", fg="red")
+    return result.returncode == 0, result.stderr
 
 
 def complete_reminder(reminder_id):

--- a/src/memo_helpers/export_memo.py
+++ b/src/memo_helpers/export_memo.py
@@ -5,7 +5,7 @@ import html2text
 import chardet
 
 
-def export_memo(path: str):
+def export_memo(path: str, quiet=False, to_markdown=False):
     script = f"""
     set exportFolder to "{path}"
     do shell script "mkdir -p " & quoted form of exportFolder
@@ -49,16 +49,21 @@ def export_memo(path: str):
     """
     result = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
     if result.returncode == 0:
-        click.secho(f"\nNotes exported to {path}", fg="green")
-        if click.confirm(
+        if not quiet:
+            click.secho(f"\nNotes exported to {path}", fg="green")
+        if quiet and to_markdown:
+            html_to_md(path, quiet=True)
+        elif not quiet and click.confirm(
             "\nDo you want to convert the notes to Markdown? Attachements and pictures will not be converted."
         ):
             html_to_md(path)
     else:
-        click.secho("\nError exporting notes", fg="red")
+        if not quiet:
+            click.secho("\nError exporting notes", fg="red")
+    return result.returncode == 0, result.stderr if result.returncode != 0 else None
 
 
-def html_to_md(path: str):
+def html_to_md(path: str, quiet=False):
     files = os.listdir(path)
     files_list = [f for f in files if os.path.isfile(os.path.join(path, f))]
 
@@ -92,4 +97,5 @@ def html_to_md(path: str):
         with open(output_path, "w", encoding="utf-8") as md_file:
             md_file.write(original_md)
 
-    click.secho("\nAll notes succesfully converted to Markdown", fg="green")
+    if not quiet:
+        click.secho("\nAll notes succesfully converted to Markdown", fg="green")

--- a/src/memo_helpers/get_memo.py
+++ b/src/memo_helpers/get_memo.py
@@ -4,10 +4,11 @@ import datetime
 from memo_helpers.cache_memo import save_cache, load_cache
 
 
-def get_note():
-    cached = load_cache()
-    if cached:
-        return list(cached)
+def get_note(use_cache=True):
+    if use_cache:
+        cached = load_cache()
+        if cached:
+            return list(cached)
 
     script = """
     set deletedTranslations to {"Recently Deleted", "Nylig slettet", "Senast raderade", "Senest slettet", "Zuletzt gelöscht", "Supprimés récemment", "Eliminados recientemente", "Eliminati di recente", "Recent verwijderd", "Ostatnio usunięte", "Недавно удалённые", "Apagados recentemente", "Apagadas recentemente", "最近删除", "最近刪除", "最近削除した項目", "최근 삭제된 항목", "Son Silinenler", "Äskettäin poistetut", "Nedávno smazané", "Πρόσφατα διαγραμμένα", "Nemrég töröltek", "Șterse recent", "Nedávno vymazané", "เพิ่งลบ", "Đã xóa gần đây", "Нещодавно видалені"}
@@ -41,7 +42,7 @@ def get_note():
 
     note_map = {i + 1: (parts[0], parts[1]) for i, parts in enumerate(notes_list)}
 
-    if not notes_list:
+    if not notes_list and use_cache:
         click.echo("No notes found.")
     seen_id = set()
     notes_list = [
@@ -50,7 +51,8 @@ def get_note():
         if id not in seen_id and not seen_id.add(id)
     ]
 
-    save_cache(note_map, notes_list)
+    if use_cache:
+        save_cache(note_map, notes_list)
     return [note_map, notes_list]
 
 

--- a/src/memo_helpers/list_folder.py
+++ b/src/memo_helpers/list_folder.py
@@ -4,25 +4,8 @@ import click
 FOLDER_SEPARATOR = "|||"
 
 
-def _build_tree(folders_with_parents):
-    """Build a folder tree from a flat list of (name, parent) tuples."""
-    children = {}
-    for name, parent in folders_with_parents:
-        children.setdefault(parent, []).append(name)
-    return children
-
-
-def _render_tree(children, parent="", indent=0):
-    """Render the folder tree as indented text."""
-    lines = []
-    for name in children.get(parent, []):
-        lines.append(" " * indent + name)
-        if name in children:
-            lines.extend(_render_tree(children, name, indent + 2))
-    return lines
-
-
-def notes_folders():
+def folders_with_parents():
+    """Return list of (name, parent) for each folder."""
     script = f"""
     tell application "Notes"
     set output to ""
@@ -44,22 +27,48 @@ def notes_folders():
     return output
     end tell
     """
-
     try:
         result = subprocess.run(
             ["osascript", "-e", script], capture_output=True, text=True, check=True
         )
         raw = result.stdout.strip()
         if not raw:
-            return ""
-
-        folders_with_parents = []
+            return []
+        folders = []
         for line in raw.split("\n"):
             if FOLDER_SEPARATOR in line:
                 name, parent = line.split(FOLDER_SEPARATOR, 1)
-                folders_with_parents.append((name.strip(), parent.strip()))
+                folders.append((name.strip(), parent.strip()))
+        return folders
+    except subprocess.CalledProcessError:
+        return []
 
-        children = _build_tree(folders_with_parents)
+
+def _build_tree(folders_with_parents_list):
+    """Build a folder tree from a flat list of (name, parent) tuples."""
+    children = {}
+    for name, parent in folders_with_parents_list:
+        children.setdefault(parent, []).append(name)
+    return children
+
+
+def _render_tree(children, parent="", indent=0):
+    """Render the folder tree as indented text."""
+    lines = []
+    for name in children.get(parent, []):
+        lines.append(" " * indent + name)
+        if name in children:
+            lines.extend(_render_tree(children, name, indent + 2))
+    return lines
+
+
+def notes_folders():
+    try:
+        folders_with_parents_list = folders_with_parents()
+        if not folders_with_parents_list:
+            return ""
+
+        children = _build_tree(folders_with_parents_list)
         lines = _render_tree(children)
         return "\n".join(lines)
     except subprocess.CalledProcessError as e:

--- a/src/memo_helpers/move_memo.py
+++ b/src/memo_helpers/move_memo.py
@@ -2,8 +2,7 @@ import subprocess
 import click
 
 
-def move_note(note_id: str, target_folder: str):
-
+def move_note(note_id: str, target_folder: str, quiet=False):
     script = f'''
     tell application "Notes"
         set noteToMove to missing value
@@ -37,6 +36,9 @@ def move_note(note_id: str, target_folder: str):
     '''
     result = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
     if result.returncode == 0:
-        click.secho(f'\n✅ The note was moved to "{target_folder}" folder.', fg="green")
+        if not quiet:
+            click.secho(f'\n✅ The note was moved to "{target_folder}" folder.', fg="green")
     else:
-        click.secho(f"\n❌ Error while moving: {result.stderr}", fg="red")
+        if not quiet:
+            click.secho(f"\n❌ Error while moving: {result.stderr}", fg="red")
+    return result.returncode == 0, result.stderr

--- a/tests/memo_notes_api_test.py
+++ b/tests/memo_notes_api_test.py
@@ -1,0 +1,309 @@
+from click.testing import CliRunner
+from memo.memo import cli
+from unittest.mock import patch, MagicMock
+
+from tests.memo_notes_test import (
+    FAKE_NOTE_ID,
+    FAKE_NOTE_TITLE,
+    FAKE_NOTE_MAP,
+    FAKE_NOTES_LIST,
+    FAKE_FOLDERS,
+)
+
+
+@patch("memo.memo.list_notes")
+def test_api_list_default_tsv(mock_list_notes):
+    mock_list_notes.return_value = f"{FAKE_NOTE_ID}\t{FAKE_FOLDERS}\t{FAKE_NOTE_TITLE}"
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "api", "list"])
+    assert result.exit_code == 0
+    assert FAKE_NOTE_ID in result.output
+    assert FAKE_FOLDERS in result.output
+    assert FAKE_NOTE_TITLE in result.output
+    mock_list_notes.assert_called_once_with(folder="", format="tsv")
+
+
+@patch("memo.memo.list_notes")
+def test_api_list_with_folder_and_json(mock_list_notes):
+    mock_list_notes.return_value = (
+        f'{{"id": "{FAKE_NOTE_ID}", "folder": "{FAKE_FOLDERS}", "title": "{FAKE_NOTE_TITLE}"}}'
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["notes", "api", "list", "--folder", FAKE_FOLDERS, "--format", "json"]
+    )
+    assert result.exit_code == 0
+    assert FAKE_NOTE_ID in result.output
+    assert FAKE_FOLDERS in result.output
+    assert FAKE_NOTE_TITLE in result.output
+    mock_list_notes.assert_called_once_with(folder=FAKE_FOLDERS, format="json")
+
+
+@patch("memo.memo.show_note")
+def test_api_show_success(mock_show_note):
+    mock_show_note.return_value = ("# Title\n\nBody", None)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "api", "show", "note-id"])
+    assert result.exit_code == 0
+    assert "# Title" in result.output
+    mock_show_note.assert_called_once_with("note-id")
+
+
+@patch("memo.memo.show_note")
+def test_api_show_error(mock_show_note):
+    mock_show_note.return_value = (None, "Failed to fetch")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "api", "show", "note-id"])
+    assert result.exit_code == 2
+    assert "Failed to fetch" in result.output
+
+
+@patch("memo.memo._read_stdin_content")
+def test_api_edit_requires_stdin(mock_read_stdin):
+    mock_read_stdin.return_value = None
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "api", "edit", "note-id"])
+    assert result.exit_code == 1
+    assert "No input provided" in result.output
+
+
+@patch("memo.memo.edit_note_stdin")
+@patch("memo.memo._read_stdin_content")
+def test_api_edit_success(mock_read_stdin, mock_edit_note_stdin):
+    mock_read_stdin.return_value = "# Updated"
+    mock_edit_note_stdin.return_value = (True, None)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["notes", "api", "edit", "note-id"], input="# Updated"
+    )
+    assert result.exit_code == 0
+    mock_edit_note_stdin.assert_called_once_with("note-id", "# Updated")
+
+
+@patch("memo.memo.edit_note_stdin")
+@patch("memo.memo._read_stdin_content")
+def test_api_edit_failure(mock_read_stdin, mock_edit_note_stdin):
+    mock_read_stdin.return_value = "# Updated"
+    mock_edit_note_stdin.return_value = (False, "Failed to update note.")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["notes", "api", "edit", "note-id"], input="# Updated"
+    )
+    assert result.exit_code == 3
+    assert "Failed to update note." in result.output
+
+
+@patch("memo.memo._read_stdin_content")
+def test_api_add_requires_stdin(mock_read_stdin):
+    mock_read_stdin.return_value = None
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "api", "add", "--folder", "Work"])
+    assert result.exit_code == 1
+    assert "No input provided" in result.output
+
+
+@patch("memo.memo.add_note_stdin")
+@patch("memo.memo._read_stdin_content")
+def test_api_add_success(mock_read_stdin, mock_add_note_stdin):
+    mock_read_stdin.return_value = "# New note"
+    mock_add_note_stdin.return_value = (True, None)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["notes", "api", "add", "--folder", "Work"], input="# New note"
+    )
+    assert result.exit_code == 0
+    mock_add_note_stdin.assert_called_once_with("Work", "# New note")
+
+
+@patch("memo.memo.add_note_stdin")
+@patch("memo.memo._read_stdin_content")
+def test_api_add_failure(mock_read_stdin, mock_add_note_stdin):
+    mock_read_stdin.return_value = "# New note"
+    mock_add_note_stdin.return_value = (False, "Failed to create note.")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["notes", "api", "add", "--folder", "Work"], input="# New note"
+    )
+    assert result.exit_code == 3
+    assert "Failed to create note." in result.output
+
+
+def test_api_add_requires_folder():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "api", "add"])
+    assert result.exit_code == 2
+    assert "Missing option '--folder'" in result.output
+
+
+@patch("memo.memo.delete_note")
+def test_api_delete_success(mock_delete_note):
+    mock_delete_note.return_value = (True, None)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "api", "delete", "note-id"])
+    assert result.exit_code == 0
+    mock_delete_note.assert_called_once_with("note-id", quiet=True)
+
+
+@patch("memo.memo.delete_note")
+def test_api_delete_failure(mock_delete_note):
+    mock_delete_note.return_value = (False, "Failed to delete note.")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "api", "delete", "note-id"])
+    assert result.exit_code == 3
+    assert "Failed to delete note." in result.output
+
+
+@patch("memo.memo.move_note")
+def test_api_move_success(mock_move_note):
+    mock_move_note.return_value = (True, None)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "api", "move", "note-id", "Target"])
+    assert result.exit_code == 0
+    mock_move_note.assert_called_once_with("note-id", "Target", quiet=True)
+
+
+@patch("memo.memo.move_note")
+def test_api_move_failure(mock_move_note):
+    mock_move_note.return_value = (False, "Failed to move note.")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "api", "move", "note-id", "Target"])
+    assert result.exit_code == 3
+    assert "Failed to move note." in result.output
+
+
+@patch("memo.memo.list_folders")
+def test_api_folders_default_format(mock_list_folders):
+    mock_list_folders.return_value = "Work\nPersonal"
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "api", "folders"])
+    assert result.exit_code == 0
+    assert "Work" in result.output
+    assert "Personal" in result.output
+    mock_list_folders.assert_called_once_with(format="tsv")
+
+
+@patch("memo.memo.list_folders")
+def test_api_folders_json_format(mock_list_folders):
+    mock_list_folders.return_value = '{"path": "Work"}'
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "api", "folders", "--format", "json"])
+    assert result.exit_code == 0
+    assert '{"path": "Work"}' in result.output
+    mock_list_folders.assert_called_once_with(format="json")
+
+
+@patch("memo.memo.search_notes")
+def test_api_search_title_only(mock_search_notes):
+    mock_search_notes.return_value = (
+        f"{FAKE_NOTE_ID}\t{FAKE_FOLDERS}\t{FAKE_NOTE_TITLE}"
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "api", "search", "Test"])
+    assert result.exit_code == 0
+    assert FAKE_NOTE_ID in result.output
+    assert FAKE_FOLDERS in result.output
+    assert FAKE_NOTE_TITLE in result.output
+    mock_search_notes.assert_called_once_with("Test", "", "tsv", search_body=False)
+
+
+@patch("memo.memo.search_notes")
+def test_api_search_with_options(mock_search_notes):
+    mock_search_notes.return_value = (
+        f"{FAKE_NOTE_ID}\t{FAKE_FOLDERS}\t{FAKE_NOTE_TITLE}"
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "notes",
+            "api",
+            "search",
+            "Test",
+            "--folder",
+            FAKE_FOLDERS,
+            "--format",
+            "json",
+            "--body",
+        ],
+    )
+    assert result.exit_code == 0
+    assert FAKE_NOTE_ID in result.output
+    assert FAKE_FOLDERS in result.output
+    assert FAKE_NOTE_TITLE in result.output
+    mock_search_notes.assert_called_once_with(
+        "Test", FAKE_FOLDERS, "json", search_body=True
+    )
+
+
+def test_api_remove_requires_force_flag():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "api", "remove", "Work"])
+    assert result.exit_code == 2
+    assert "Missing option '--force'" in result.output
+
+
+@patch("memo.memo.delete_note_folder")
+def test_api_remove_success(mock_delete_note_folder):
+    mock_delete_note_folder.return_value = (True, None)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["notes", "api", "remove", "Work/Meetings", "--force"]
+    )
+    assert result.exit_code == 0
+    mock_delete_note_folder.assert_called_once_with("Work/Meetings", quiet=True)
+
+
+@patch("memo.memo.delete_note_folder")
+def test_api_remove_failure(mock_delete_note_folder):
+    mock_delete_note_folder.return_value = (False, "Failed to remove folder.")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["notes", "api", "remove", "Work/Meetings", "--force"]
+    )
+    assert result.exit_code == 3
+    assert "Failed to remove folder." in result.output
+
+
+@patch("memo.memo.os.makedirs")
+@patch("memo.memo.os.path.exists")
+@patch("memo.memo.export_memo")
+def test_api_export_creates_directory_and_exports(
+    mock_export_memo, mock_path_exists, mock_makedirs
+):
+    mock_path_exists.return_value = False
+    mock_export_memo.return_value = (True, None)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["notes", "api", "export", "--path", "/tmp/memo-export"]
+    )
+    assert result.exit_code == 0
+    mock_path_exists.assert_any_call("/tmp/memo-export")
+    mock_makedirs.assert_called_once_with("/tmp/memo-export", exist_ok=True)
+    mock_export_memo.assert_called_once_with(
+        "/tmp/memo-export", quiet=True, to_markdown=False
+    )
+
+
+@patch("memo.memo.os.path.exists")
+@patch("memo.memo.export_memo")
+def test_api_export_failure(mock_export_memo, mock_path_exists):
+    mock_path_exists.return_value = True
+    mock_export_memo.return_value = (False, "Failed to export.")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "notes",
+            "api",
+            "export",
+            "--path",
+            "/tmp/memo-export",
+            "--markdown",
+        ],
+    )
+    assert result.exit_code == 3
+    assert "Failed to export." in result.output
+    mock_export_memo.assert_called_once_with(
+        "/tmp/memo-export", quiet=True, to_markdown=True
+    )
+


### PR DESCRIPTION
## What this changes

This PR adds a new `memo notes api` subcommand for a non-interactive, machine-friendly API, intended to be used without interactive editor.

## How I tested this

- Performed manual testing of new features
- Ran the Python test suite with `pytest` in the project’s `uv`-managed virtualenv
- Verified new `tests/memo_notes_api_test.py` covers all `memo notes api` subcommands

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR follows the guidelines
- [x] A human has reviewed the **entire diff** of this PR, every line of code
- [x] A human understands the changes and can explain why this approach is correct
- [ ] This PR doesn't have AI-generated boilerplate or co-author lines
- [ ] This PR was authored and submitted by an AI agent without human review