### PR TITLE
feat: add non-interactive note creation via --title/--body and stdin

### DIFF
--- a/src/memo/memo.py
+++ b/src/memo/memo.py
@@ -94,11 +94,28 @@ def cli():
     default=None,
     help="Display the content of note N from the list.",
 )
+@click.option(
+    "--title",
+    "-t",
+    default=None,
+    help="Title for the new note (use with --add and --folder for non-interactive creation).",
+)
+@click.option(
+    "--body",
+    "-b",
+    default=None,
+    help=(
+        "Body for the new note (use with --add and --folder). "
+        "Pass '-' to read from stdin."
+    ),
+)
 def notes(
-    folder, edit, add, delete, move, flist, search, remove, export, view, no_cache
+    folder, edit, add, delete, move, flist, search, remove, export, view, no_cache,
+    title, body
 ):
     selection_notes_validation(
-        folder, edit, delete, move, add, flist, search, remove, export, view
+        folder, edit, delete, move, add, flist, search, remove, export, view,
+        title, body
     )
     if no_cache:
         clear_cache()
@@ -141,7 +158,8 @@ def notes(
         edit_note(note_id)
         clear_cache()
     if add:
-        add_note(folder)
+        body_content = click.get_text_stream("stdin").read() if body == "-" else body
+        add_note(folder, title=title, body=body_content)
         clear_cache()
     if move:
         note_id = pick_note(note_map, notes_list_filter, "move")

--- a/src/memo_helpers/add_memo.py
+++ b/src/memo_helpers/add_memo.py
@@ -3,32 +3,65 @@ import click
 import tempfile
 import mistune
 import os
+import sys
 from datetime import datetime
 
 
-def add_note(folder_name):
-    with tempfile.NamedTemporaryFile(suffix=".md", delete=False) as temp_file:
-        temp_file.write(b"# Your note title\n\nWrite your note here...")
-        temp_file_path = temp_file.name
+def _escape_applescript_string(s):
+    """Escape a string for safe embedding in an AppleScript double-quoted string."""
+    return s.replace("\\", "\\\\").replace('"', '\\"')
 
-    editor = os.getenv("EDITOR", "vim")
-    subprocess.run([editor, temp_file_path])
 
-    with open(temp_file_path, "r", encoding="utf-8") as file:
-        note_md = file.read().strip()
+def add_note(folder_name, title=None, body=None):
+    """Create a note in the given Notes folder.
 
-    if not note_md or note_md == "# Your note title\n\nWrite your note here...":
-        click.echo("\nNote creation cancelled.")
+    When *title* and/or *body* are provided the editor is skipped entirely,
+    making the function safe to call from non-interactive environments such as
+    shell pipelines or AI agents.
+
+    If neither argument is supplied and stdin is not a TTY (i.e. content is
+    being piped in), the piped text is treated as Markdown and used directly.
+
+    Falls back to opening ``$EDITOR`` when running interactively with no
+    arguments.
+    """
+    if title is not None or body is not None:
+        # Non-interactive: build note from provided arguments.
+        note_title = title if title is not None else "Untitled"
+        note_body = body if body is not None else ""
+        note_md = f"# {note_title}\n\n{note_body}" if note_body else f"# {note_title}"
+    elif not sys.stdin.isatty():
+        # Stdin is a pipe: treat the piped text as Markdown.
+        note_md = sys.stdin.read().strip()
+        if not note_md:
+            click.echo("\nNote creation cancelled.")
+            return
+    else:
+        # Interactive fallback: open the user's preferred editor.
+        with tempfile.NamedTemporaryFile(suffix=".md", delete=False) as temp_file:
+            temp_file.write(b"# Your note title\n\nWrite your note here...")
+            temp_file_path = temp_file.name
+
+        editor = os.getenv("EDITOR", "vim")
+        subprocess.run([editor, temp_file_path])
+
+        with open(temp_file_path, "r", encoding="utf-8") as file:
+            note_md = file.read().strip()
+
         os.remove(temp_file_path)
-        return
+
+        if not note_md or note_md == "# Your note title\n\nWrite your note here...":
+            click.echo("\nNote creation cancelled.")
+            return
 
     note_html = mistune.markdown(note_md)
+    escaped_html = _escape_applescript_string(note_html)
 
     script = f"""
         tell application "Notes"
             set targetFolder to first folder whose name is "{folder_name}"
             tell targetFolder
-                make new note with properties {{body:"{note_html}"}}
+                make new note with properties {{body:"{escaped_html}"}}
             end tell
         end tell
         """
@@ -36,8 +69,6 @@ def add_note(folder_name):
     process = subprocess.run(
         ["osascript", "-e", script], capture_output=True, text=True
     )
-
-    os.remove(temp_file_path)
 
     if process.returncode == 0:
         click.echo(f"\nNote created in '{folder_name}' folder.")

--- a/src/memo_helpers/validation_memo.py
+++ b/src/memo_helpers/validation_memo.py
@@ -2,7 +2,8 @@ import click
 
 
 def selection_notes_validation(
-    folder, edit, delete, move, add, flist, search, remove, export, view
+    folder, edit, delete, move, add, flist, search, remove, export, view,
+    title=None, body=None
 ):
     used_flags = {
         "folder": bool(folder),
@@ -20,6 +21,11 @@ def selection_notes_validation(
     if add and not folder:
         raise click.UsageError(
             "--add must be used indicating a folder to create the note to."
+        )
+
+    if (title is not None or body is not None) and not add:
+        raise click.UsageError(
+            "--title and --body must be used with --add."
         )
 
     if flist and sum(used_flags.values()) > 1:

--- a/tests/memo_notes_test.py
+++ b/tests/memo_notes_test.py
@@ -132,3 +132,93 @@ def test_notes_view_combined_with_edit():
     result = runner.invoke(cli, ["notes", "--view", "1", "--edit"])
     assert result.exit_code == 2
     assert "Only one of" in result.output
+
+
+# --- Non-interactive add tests ---
+
+
+@patch("memo_helpers.add_memo.subprocess.run")
+@patch("memo.memo.notes_folders")
+@patch("memo.memo.get_note")
+def test_notes_add_noninteractive_title_and_body(
+    mock_get_note, mock_notes_folders, mock_subprocess
+):
+    """--title and --body skip the editor and create the note directly."""
+    mock_get_note.return_value = [FAKE_NOTE_MAP, FAKE_NOTES_LIST]
+    mock_notes_folders.return_value = FAKE_FOLDERS
+    mock_subprocess.return_value = MagicMock(returncode=0, stderr="", stdout="")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "notes",
+            "--add",
+            "--folder", "My Folder",
+            "--title", "My Test Note",
+            "--body", "Hello from the test.",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Note created in 'My Folder' folder." in result.output
+    # The editor must NOT have been opened — only osascript should have been called.
+    called_commands = [call.args[0] for call in mock_subprocess.call_args_list]
+    assert all(cmd[0] == "osascript" for cmd in called_commands)
+
+
+@patch("memo_helpers.add_memo.subprocess.run")
+@patch("memo.memo.notes_folders")
+@patch("memo.memo.get_note")
+def test_notes_add_noninteractive_title_only(
+    mock_get_note, mock_notes_folders, mock_subprocess
+):
+    """--title without --body creates a note with a title and no body."""
+    mock_get_note.return_value = [FAKE_NOTE_MAP, FAKE_NOTES_LIST]
+    mock_notes_folders.return_value = FAKE_FOLDERS
+    mock_subprocess.return_value = MagicMock(returncode=0, stderr="", stdout="")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["notes", "--add", "--folder", "My Folder", "--title", "Title Only"],
+    )
+    assert result.exit_code == 0
+    assert "Note created in 'My Folder' folder." in result.output
+
+
+def test_notes_add_title_without_add_flag():
+    """--title without --add should raise a UsageError."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["notes", "--folder", "My Folder", "--title", "Orphaned Title"]
+    )
+    assert result.exit_code == 2
+    assert "--title and --body must be used with --add." in result.output
+
+
+def test_notes_add_body_without_add_flag():
+    """--body without --add should raise a UsageError."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["notes", "--folder", "My Folder", "--body", "Orphaned body"]
+    )
+    assert result.exit_code == 2
+    assert "--title and --body must be used with --add." in result.output
+
+
+@patch("memo_helpers.add_memo.subprocess.run")
+@patch("memo.memo.notes_folders")
+@patch("memo.memo.get_note")
+def test_notes_add_noninteractive_stdin(
+    mock_get_note, mock_notes_folders, mock_subprocess
+):
+    """Piped stdin content is used as Markdown when no --title/--body given."""
+    mock_get_note.return_value = [FAKE_NOTE_MAP, FAKE_NOTES_LIST]
+    mock_notes_folders.return_value = FAKE_FOLDERS
+    mock_subprocess.return_value = MagicMock(returncode=0, stderr="", stdout="")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["notes", "--add", "--folder", "My Folder"],
+        input="# Piped Note\n\nThis came from stdin.",
+    )
+    assert result.exit_code == 0
+    assert "Note created in 'My Folder' folder." in result.output


### PR DESCRIPTION
## Problem

`memo notes --add` currently always opens `$EDITOR`, which makes it impossible to use in:
- shell pipelines (e.g. `echo "# Note" | memo notes --add --folder Notes`)
- automated scripts
- AI agents — even though the README explicitly says memo is used by [OpenClaw](https://github.com/openclaw/openclaw)

There is no way to pass note content non-interactively today.

## Solution

Add two new options to `memo notes`:

| Option | Short | Description |
|---|---|---|
| `--title TEXT` | `-t` | Note title (skips editor when provided) |
| `--body TEXT` | `-b` | Note body. Pass `-` to read from stdin |

When either flag is given the editor is bypassed entirely. When neither is given but stdin is not a TTY, piped Markdown is used directly. The original interactive editor path is completely unchanged.

### Examples

```bash
# Fully non-interactive
memo notes --add --folder "Work" --title "Stand-up" --body "- shipped auth PR"

# Title only (empty body)
memo notes --add --folder "Inbox" --title "Read later"

# Pipe Markdown
echo "# Ideas\n\n- rewrite in Rust" | memo notes --add --folder "Scratch"

# Explicit stdin
cat my_note.md | memo notes --add --folder "Notes" --body -
```

## Changes

- **`add_memo.py`**: refactor `add_note()` to accept optional `title` and `body` args; add stdin detection; fix latent AppleScript string-injection bug (backslashes and double-quotes in generated HTML were not escaped before being embedded in the script string)
- **`memo.py`**: add `--title` / `-t` and `--body` / `-b` options; pass them through to `add_note()`
- **`validation_memo.py`**: raise `UsageError` when `--title` or `--body` are used without `--add`
- **`tests/memo_notes_test.py`**: add 5 new tests covering all non-interactive paths

## Tests

All 28 existing + new tests pass:

```
28 passed in 2.98s
```

## AI note:

I personally reviewed and will sign off on this work that was done mostly by Claude Sonnet 4.5 as my Openclaw agent