### PR TITLE
fix: add cycle detection to _render_tree to prevent RecursionError

### DIFF
--- a/src/memo_helpers/list_folder.py
+++ b/src/memo_helpers/list_folder.py
@@ -12,13 +12,16 @@ def _build_tree(folders_with_parents):
     return children
 
 
-def _render_tree(children, parent="", indent=0):
+def _render_tree(children, parent="", indent=0, visited=None):
     """Render the folder tree as indented text."""
+    if visited is None:
+        visited = set()
     lines = []
     for name in children.get(parent, []):
         lines.append(" " * indent + name)
-        if name in children:
-            lines.extend(_render_tree(children, name, indent + 2))
+        if name in children and name not in visited:
+            visited.add(name)
+            lines.extend(_render_tree(children, name, indent + 2, visited))
     return lines
 
 


### PR DESCRIPTION
## What this changes

I was hitting a `RecursionError` every time I ran `memo notes` — turns out `_render_tree` gets stuck in an infinite loop when Apple Notes has folders with circular parent references (folder A points to B, B points back to A).

I noticed #25 reported the same crash. It was closed with v0.5.1, but the recursion issue is still there — the perf improvements helped with speed but didn't add any cycle guard to `_render_tree`.

The fix is small: a `visited` set that tracks which folders we've already rendered, so we skip them instead of recursing forever.

## How I tested this

Ran `memo notes` on my Mac (v0.5.1) with 900+ notes across nested folders.
Before: instant crash (989 recursive calls). After: works fine, all notes show up.

## Checklist

- [x] I have read CONTRIBUTING.md and this PR follows the guidelines
- [x] A human has reviewed the entire diff of this PR, every line of code
- [x] A human understands the changes and can explain why this approach is correct
- [x] This PR doesn't have AI-generated boilerplate or co-author lines
- [ ] This PR was authored and submitted by an AI agent without human review