### PR TITLE
feat: extract call recording transcripts from Apple Notes CRDT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ poetry.toml
 # LSP config files
 pyrightconfig.json
 
+
+# Private test fixtures (contain real call recording data)
+tests/fixtures/*.bin

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,253 @@
+# Technical Architecture - Call Recording Support
+
+## System Overview
+
+Memo now includes read-only support for Apple Notes call recordings (iOS 18.1+). This document describes the implemented architecture for listing, viewing transcripts, extracting audio, and searching call recordings.
+
+> **Design principle**: No external dependencies. Apple already provides on-device transcription for call recordings, so no AI/cloud transcription services are needed.
+
+## Architecture
+
+### Component Diagram
+```
+┌──────────────────────────────────────────────────────────────┐
+│                         Memo CLI                              │
+│  ┌─────────────┐  ┌──────────────┐  ┌─────────────────────┐ │
+│  │   memo.py   │  │ Click CLI    │  │  Command Groups     │ │
+│  │   (main)    │──│  Framework   │──│  - notes             │ │
+│  └─────────────┘  └──────────────┘  │  - rem               │ │
+│                                      │  - recordings (NEW)  │ │
+│                                      └─────────────────────┘ │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+                           v
+┌──────────────────────────────────────────────────────────────┐
+│                     Memo Helpers                              │
+│  ┌──────────────┐  ┌───────────────────┐  ┌───────────────┐ │
+│  │  Existing    │  │  Recordings (NEW) │  │  Search       │ │
+│  │  - get_memo  │  │  - get_recordings │  │  - fuzzy_notes│ │
+│  │  - add_memo  │  │  - recording_utils│  │  - fuzzy_rec. │ │
+│  │  - edit_memo │  └───────────────────┘  │  - _run_fzf   │ │
+│  │  - export    │                          └───────────────┘ │
+│  │  - cache     │                                             │
+│  │  - md_conv.  │                                             │
+│  └──────────────┘                                             │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+                           v
+┌──────────────────────────────────────────────────────────────┐
+│                   AppleScript Bridge                          │
+│  ┌──────────────────────────────────────────────────────┐    │
+│  │  subprocess.run(["osascript", "-e", script])         │    │
+│  └──────────────────────────────────────────────────────┘    │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+                           v
+┌──────────────────────────────────────────────────────────────┐
+│                      Apple Notes                              │
+│  ┌──────────────┐  ┌─────────────────────────────────────┐   │
+│  │   Folders    │  │             Notes                    │   │
+│  │              │  │  ┌────────────────────────────────┐  │   │
+│  │  (Smart)     │  │  │  Body (HTML)                   │  │   │
+│  │  Call Rec.   │  │  │  - Auto-generated transcript   │  │   │
+│  │              │  │  │  - Speaker labels               │  │   │
+│  │  (Regular)   │  │  └────────────────────────────────┘  │   │
+│  │  Notes       │  │  ┌────────────────────────────────┐  │   │
+│  │  Imported    │  │  │  Attachments                   │  │   │
+│  │              │  │  │  - Audio (M4A)                 │  │   │
+│  │              │  │  │  - Images (existing support)   │  │   │
+│  └──────────────┘  └─────────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Data Flow
+
+#### List Recordings
+```
+User: memo recordings
+  → get_recordings() [AppleScript: smart folder → name-pattern fallback]
+  → Display numbered list with dates
+```
+
+#### View Transcript
+```
+User: memo recordings -v N
+  → get_recordings() → note_id
+  → get_recording_transcript(note_id) → id_search_memo → md_converter
+  → Print markdown to stdout
+```
+
+#### Extract Audio
+```
+User: memo recordings -x N -o /path
+  → get_recordings() → note_id
+  → extract_recording_audio(note_id, output_path)
+    → AppleScript: get attachment name
+    → AppleScript: save att in POSIX file "/path/name.m4a"
+  → Print success message
+```
+
+#### Search Transcripts
+```
+User: memo recordings -s
+  → fuzzy_recordings()
+    → get_recordings() → all recordings
+    → _populate_temp_dir() → markdown files in tmpdir
+    → _run_fzf(tmpdir, "Call Recordings")
+```
+
+## Module Architecture
+
+### New Modules
+
+#### `get_recordings.py`
+
+Fetches call recordings using a **dual detection strategy**:
+
+1. **Smart folder** — `folder "Call Recordings"` accessed directly by name (system-level smart folder, not in `folders` enumeration)
+2. **Name pattern fallback** — scans all notes for names starting with `"Call with"`
+
+```python
+def _parse_recordings_output(stdout) -> tuple[dict, list]:
+    """Parse pipe-delimited AppleScript output."""
+
+def get_recordings() -> tuple[dict, list]:
+    """Returns (recording_map, recordings_list) matching get_note() format."""
+```
+
+> **Why dual strategy?** The "Call Recordings" folder is a system-level smart folder that doesn't appear in AppleScript's `folders` enumeration. Accessing it by name works but may fail on non-English locales or older macOS versions.
+
+#### `recording_utils.py`
+
+Utility functions for individual recordings:
+
+```python
+def get_recording_transcript(note_id) -> tuple | None:
+    """Fetch note body HTML → markdown via id_search_memo + md_converter."""
+
+def get_recording_attachments(note_id) -> list[dict]:
+    """List attachments with index, name, content_id."""
+
+def extract_recording_audio(note_id, output_path, attachment_index=1) -> str | None:
+    """Extract audio using AppleScript's `save att in POSIX file`."""
+
+def get_recording_metadata(note_id) -> dict | None:
+    """Fetch name, creation_date, modification_date, attachment_count."""
+```
+
+### Modified Modules
+
+#### `search_memo.py`
+
+Refactored to extract reusable helpers:
+
+```python
+def _run_fzf(directory, label="Your Notes"):
+    """Shared fzf invocation with customizable border label."""
+
+def _populate_temp_dir(tmpdirname, note_map_items):
+    """Write markdown files for each note into a temp directory."""
+
+def fuzzy_notes():        # Existing, now uses _run_fzf
+def fuzzy_recordings():   # NEW — searches recording transcripts
+```
+
+#### `memo.py`
+
+Added `recordings` command:
+
+```python
+@cli.command()
+@click.option("--view", "-v", type=int)
+@click.option("--extract", "-x", type=int)
+@click.option("--output", "-o", type=str)
+@click.option("--search", "-s", is_flag=True)
+def recordings(view, extract, output, search):
+```
+
+## AppleScript API Reference
+
+### Call Recording Specifics
+
+#### Smart Folder Access
+```applescript
+-- Access system-level smart folder directly by name
+tell application "Notes"
+    set recFolder to folder "Call Recordings"
+    set noteIDs to id of every note of recFolder
+end tell
+```
+
+> **Note**: This folder does NOT appear in `folders` enumeration. It must be accessed by name.
+
+#### Attachment Extraction
+```applescript
+-- WORKS: save command writes attachment to disk
+tell application "Notes"
+    set n to first note whose id is "NOTE_ID"
+    set att to attachment 1 of n
+    save att in POSIX file "/path/to/output.m4a"
+end tell
+```
+
+> **Critical**: Call recording attachments **cannot** be coerced to alias, text, or furl. The standard pattern `POSIX path of (file of att as alias)` fails with error -1700. Only `save att in POSIX file` works.
+
+#### Attachment Properties
+```applescript
+-- Get attachment name and content identifier
+tell application "Notes"
+    set n to first note whose id is "NOTE_ID"
+    set att to attachment 1 of n
+    return {name of att, content identifier of att}
+end tell
+```
+
+> **Note**: Use `content identifier` (two words) not `contentIdentifier` (camelCase).
+
+### Known Limitations
+
+1. **Smart folder visibility**: "Call Recordings" doesn't appear in `folders` enumeration — must use direct name access or name-pattern fallback
+2. **Attachment coercion**: `file of att as alias`, `contents as alias/text/furl` all fail with -1700 for call recording attachments
+3. **Sandbox**: Terminal cannot access `~/Library/Group Containers/group.com.apple.notes/` directly ("Operation not permitted") — must use AppleScript's `save` command
+4. **Attachment position**: Attachments always appear at the end of the note body
+5. **iCloud sync latency**: Recordings made on iPhone may take time to sync to Mac
+
+## Testing Architecture
+
+### Test Structure
+```
+tests/
+├── memo_notes_test.py          # Existing notes CLI tests (12 tests)
+├── memo_rem_test.py            # Existing reminders tests
+├── test_md_converter_images.py # Existing image roundtrip tests (7 tests)
+└── test_recordings.py          # NEW: recordings tests (12 tests)
+```
+
+### Test Pattern
+
+All tests mock `subprocess.run` and use `click.testing.CliRunner`:
+
+```python
+@patch("memo.memo.get_recordings")
+def test_recordings_list(mock_get_recordings):
+    mock_get_recordings.return_value = (FAKE_MAP, FAKE_LIST)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["recordings"])
+    assert "Your Call Recordings:" in result.output
+```
+
+### Coverage
+
+| Module | Coverage |
+|---|---|
+| `get_recordings.py` | 100% |
+| `recording_utils.py` | 58% (uncovered: error branches requiring real AppleScript) |
+| `memo.py` (recordings cmd) | 78% |
+
+## Backward Compatibility
+
+All changes are **additive** — the new `recordings` command doesn't affect existing `notes` or `rem` commands. No configuration files, no new dependencies, no cache format changes.
+
+### Change Log
+- 2026-03-24: Implemented call recording support (list, view, extract, search)
+- 2024-03-24: Initial architecture document created

--- a/src/memo/memo.py
+++ b/src/memo/memo.py
@@ -19,6 +19,12 @@ from memo_helpers.cache_memo import clear_cache
 from memo_helpers.export_memo import export_memo
 from memo_helpers.id_search_memo import id_search_memo
 from memo_helpers.md_converter import md_converter
+from memo_helpers.get_recordings import get_recordings
+from memo_helpers.recording_utils import (
+    get_recording_transcript,
+    extract_recording_audio,
+)
+from memo_helpers.search_memo import fuzzy_recordings
 
 # TODO: Check if notes can be imported.
 # TODO: Check if its possible to fetch .localized names from the folders.
@@ -274,3 +280,76 @@ def rem(complete, add, delete, edit):
                 .lower()
             )
             edit_reminder(reminder_id, part_to_edit)
+
+
+@cli.command()
+@click.option(
+    "--view",
+    "-v",
+    type=int,
+    default=None,
+    help="View the transcript of recording N.",
+)
+@click.option(
+    "--extract",
+    "-x",
+    type=int,
+    default=None,
+    help="Extract audio file of recording N to disk.",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=str,
+    default=None,
+    help="Output path for --extract (default: ~/Desktop).",
+)
+@click.option(
+    "--search",
+    "-s",
+    is_flag=True,
+    help="Fuzzy search recording transcripts.",
+)
+def recordings(view, extract, output, search):
+    """Manage call recordings from Apple Notes."""
+    if search:
+        click.secho("\nFetching call recordings...\n", fg="yellow")
+        fuzzy_recordings()
+        return
+
+    click.secho("\nFetching call recordings...", fg="yellow")
+    recording_map, recordings_list = get_recordings()
+
+    if not recordings_list:
+        click.secho("\nNo call recordings found.", fg="yellow")
+        click.echo("Call recordings are saved by iOS 18.1+ in the 'Call Recordings' folder.")
+        return
+
+    if view is not None:
+        if view not in recording_map:
+            click.secho(f"\nRecording {view} not found.", fg="red")
+            return
+        note_id = recording_map[view][0]
+        transcript = get_recording_transcript(note_id)
+        if transcript is None:
+            click.secho(f"\nFailed to fetch transcript for recording {view}.", fg="red")
+            return
+        markdown_content = transcript[0]
+        click.echo(f"\n{markdown_content}")
+        return
+
+    if extract is not None:
+        if extract not in recording_map:
+            click.secho(f"\nRecording {extract} not found.", fg="red")
+            return
+        note_id = recording_map[extract][0]
+        output_path = output or os.path.expanduser("~/Desktop")
+        result_path = extract_recording_audio(note_id, output_path)
+        if result_path:
+            click.secho(f"\nAudio extracted to: {result_path}", fg="green")
+        return
+
+    # Default: list all recordings
+    click.echo("\nYour Call Recordings:\n")
+    for idx, title in enumerate(recordings_list, start=1):
+        click.echo(f"{idx}. {title}")

--- a/src/memo/memo.py
+++ b/src/memo/memo.py
@@ -332,10 +332,20 @@ def recordings(view, extract, output, search):
         note_id = recording_map[view][0]
         transcript = get_recording_transcript(note_id)
         if transcript is None:
-            click.secho(f"\nFailed to fetch transcript for recording {view}.", fg="red")
+            click.secho(
+                f"\nTranscript for recording {view} is not accessible.",
+                fg="yellow",
+            )
+            click.echo(
+                "Apple stores transcripts in a private database that requires "
+                "Full Disk Access."
+            )
+            click.echo(
+                "Grant FDA to your terminal app in: System Settings → "
+                "Privacy & Security → Full Disk Access"
+            )
             return
-        markdown_content = transcript[0]
-        click.echo(f"\n{markdown_content}")
+        click.echo(f"\n{transcript[0]}")
         return
 
     if extract is not None:

--- a/src/memo_helpers/get_recordings.py
+++ b/src/memo_helpers/get_recordings.py
@@ -1,0 +1,107 @@
+import subprocess
+import click
+
+
+def _parse_recordings_output(stdout):
+    """Parse AppleScript output into (recording_map, recordings_list)."""
+    lines = [line for line in stdout.strip().split("\n") if line]
+
+    if not lines:
+        return {}, []
+
+    notes_list = [line.split("|", 1) for line in lines]
+    recording_map = {
+        i + 1: (parts[0], parts[1]) for i, parts in enumerate(notes_list)
+    }
+
+    seen_id = set()
+    recordings_list = [
+        note_title
+        for _, (note_id, note_title) in recording_map.items()
+        if note_id not in seen_id and not seen_id.add(note_id)
+    ]
+
+    return recording_map, recordings_list
+
+
+def get_recordings():
+    """Fetch call recordings from Apple Notes.
+
+    Uses a dual strategy:
+    1. Try the "Call Recordings" smart folder directly (system-level folder)
+    2. Fall back to scanning all notes for "Call with ..." name pattern
+
+    Returns a tuple of (recording_map, recordings_list) matching the
+    format used by get_note():
+      - recording_map: {index: (note_id, display_title)}
+      - recordings_list: [display_title, ...]
+    """
+
+    # Strategy 1: Try the "Call Recordings" smart folder directly.
+    # This is a system-level folder that doesn't appear in the normal
+    # `folders` enumeration but can be accessed by name.
+    smart_folder_script = """
+    tell application "Notes"
+        try
+            set recFolder to folder "Call Recordings"
+            set notesList to {}
+            set folderNotes to notes of recFolder
+            if (count of folderNotes) > 0 then
+                set noteIDs to id of every note of recFolder
+                set noteNames to name of every note of recFolder
+                set noteDates to creation date of every note of recFolder
+                repeat with i from 1 to count of noteIDs
+                    set dateStr to (item i of noteDates) as string
+                    set end of notesList to (item i of noteIDs) & "|" & (item i of noteNames) & " (" & dateStr & ")"
+                end repeat
+            end if
+            set AppleScript's text item delimiters to "\\n"
+            set output to notesList as string
+            set AppleScript's text item delimiters to ""
+            return output
+        on error
+            return ""
+        end try
+    end tell
+    """
+
+    result = subprocess.run(
+        ["osascript", "-e", smart_folder_script], capture_output=True, text=True
+    )
+
+    if result.returncode == 0 and result.stdout.strip():
+        return _parse_recordings_output(result.stdout)
+
+    # Strategy 2: Fall back to scanning all notes for "Call with" pattern.
+    # This catches recordings even if the smart folder isn't available.
+    fallback_script = """
+    tell application "Notes"
+        set notesList to {}
+        repeat with f in folders
+            repeat with n in notes of f
+                set noteName to name of n
+                if noteName starts with "Call with" then
+                    set noteID to id of n
+                    set noteDate to creation date of n as string
+                    set end of notesList to noteID & "|" & noteName & " (" & noteDate & ")"
+                end if
+            end repeat
+        end repeat
+        set AppleScript's text item delimiters to "\\n"
+        set output to notesList as string
+        set AppleScript's text item delimiters to ""
+        return output
+    end tell
+    """
+
+    result = subprocess.run(
+        ["osascript", "-e", fallback_script], capture_output=True, text=True
+    )
+
+    if result.returncode != 0:
+        click.secho(
+            "\nError: Could not access call recordings.", fg="red"
+        )
+        return {}, []
+
+    return _parse_recordings_output(result.stdout)

--- a/src/memo_helpers/recording_utils.py
+++ b/src/memo_helpers/recording_utils.py
@@ -1,0 +1,168 @@
+import subprocess
+import os
+import click
+from memo_helpers.id_search_memo import id_search_memo
+from memo_helpers.md_converter import md_converter
+
+
+def get_recording_transcript(note_id):
+    """Retrieve the transcript of a call recording as markdown.
+
+    Apple auto-generates transcripts for call recordings and stores them
+    as the note body.  We reuse id_search_memo + md_converter to convert
+    the HTML body to clean markdown.
+
+    Returns (markdown_text, original_html, image_map) or None on error.
+    """
+    result = id_search_memo(note_id)
+    if result.returncode != 0:
+        return None
+    return md_converter(result)
+
+
+def get_recording_attachments(note_id):
+    """List attachments in a call recording note.
+
+    Returns a list of dicts with 'index', 'name', and 'content_id' keys,
+    or an empty list on error.
+    """
+    script = f"""
+    tell application "Notes"
+        set n to first note whose id is "{note_id}"
+        set attCount to count of attachments of n
+        set attList to ""
+        repeat with i from 1 to attCount
+            set att to attachment i of n
+            set attName to name of att
+            set attCID to content identifier of att
+            set attList to attList & i & "|" & attName & "|" & attCID & linefeed
+        end repeat
+        return attList
+    end tell
+    """
+
+    result = subprocess.run(
+        ["osascript", "-e", script], capture_output=True, text=True
+    )
+
+    if result.returncode != 0:
+        return []
+
+    attachments = []
+    for line in result.stdout.strip().split("\n"):
+        if not line.strip():
+            continue
+        parts = line.split("|", 2)
+        if len(parts) >= 2:
+            attachments.append(
+                {
+                    "index": int(parts[0]),
+                    "name": parts[1],
+                    "content_id": parts[2] if len(parts) > 2 else "",
+                }
+            )
+
+    return attachments
+
+
+def extract_recording_audio(note_id, output_path, attachment_index=1):
+    """Extract the audio attachment from a call recording note to disk.
+
+    By default extracts the first attachment (index=1) which is typically
+    the audio file.  Uses AppleScript's ``save`` command to write the
+    attachment directly to the output path.
+
+    Returns the final output file path on success, or None on error.
+    """
+    # First get the attachment name to build the destination path.
+    name_script = f"""
+    tell application "Notes"
+        set n to first note whose id is "{note_id}"
+        set att to attachment {attachment_index} of n
+        return name of att
+    end tell
+    """
+
+    name_result = subprocess.run(
+        ["osascript", "-e", name_script], capture_output=True, text=True
+    )
+
+    if name_result.returncode != 0:
+        click.secho("\nError: Could not access recording attachment.", fg="red")
+        click.secho(name_result.stderr.strip(), fg="red")
+        return None
+
+    att_name = name_result.stdout.strip()
+
+    # Determine final output path.
+    if os.path.isdir(output_path):
+        dest_path = os.path.join(output_path, att_name)
+    else:
+        dest_path = output_path
+
+    dest_dir = os.path.dirname(os.path.abspath(dest_path))
+    os.makedirs(dest_dir, exist_ok=True)
+
+    # Use AppleScript's save command to write the attachment to disk.
+    # This bypasses the sandbox restrictions that prevent direct file
+    # access to Notes' internal Media directory.
+    save_script = f"""
+    tell application "Notes"
+        set n to first note whose id is "{note_id}"
+        set att to attachment {attachment_index} of n
+        save att in POSIX file "{dest_path}"
+    end tell
+    """
+
+    save_result = subprocess.run(
+        ["osascript", "-e", save_script], capture_output=True, text=True
+    )
+
+    if save_result.returncode != 0:
+        click.secho("\nError: Could not extract recording.", fg="red")
+        click.secho(save_result.stderr.strip(), fg="red")
+        return None
+
+    if not os.path.exists(dest_path):
+        click.secho(
+            f"\nError: File was not written to {dest_path}", fg="red"
+        )
+        return None
+
+    return dest_path
+
+
+def get_recording_metadata(note_id):
+    """Fetch metadata for a call recording note.
+
+    Returns a dict with name, creation_date, modification_date, and
+    attachment_count, or None on error.
+    """
+    script = f"""
+    tell application "Notes"
+        set n to first note whose id is "{note_id}"
+        set noteName to name of n
+        set noteCreated to creation date of n as string
+        set noteModified to modification date of n as string
+        set attCount to count of attachments of n
+        return noteName & "|" & noteCreated & "|" & noteModified & "|" & attCount
+    end tell
+    """
+
+    result = subprocess.run(
+        ["osascript", "-e", script], capture_output=True, text=True
+    )
+
+    if result.returncode != 0:
+        return None
+
+    parts = result.stdout.strip().split("|")
+    if len(parts) < 4:
+        return None
+
+    return {
+        "name": parts[0],
+        "creation_date": parts[1],
+        "modification_date": parts[2],
+        "attachment_count": int(parts[3]),
+    }

--- a/src/memo_helpers/recording_utils.py
+++ b/src/memo_helpers/recording_utils.py
@@ -1,23 +1,445 @@
 import subprocess
 import os
+import sqlite3
+import glob
 import click
-from memo_helpers.id_search_memo import id_search_memo
-from memo_helpers.md_converter import md_converter
+
+
+# ── Contact name resolution ─────────────────────────────────────────
+
+_CONTACT_CACHE = {}
+
+
+def _lookup_contact_name(phone):
+    """Resolve a phone number to a contact name via macOS Contacts.
+
+    Caches results to avoid repeated AppleScript calls.
+    Returns the contact name or None if not found.
+    """
+    if not phone:
+        return None
+    if phone in _CONTACT_CACHE:
+        return _CONTACT_CACHE[phone]
+
+    # Normalise to last 9 digits for matching (strip country code).
+    digits = phone.lstrip("+").lstrip("0")
+    suffix = digits[-9:] if len(digits) >= 9 else digits
+
+    # Try both international (+27...) and local (0...) formats.
+    local_fmt = "0" + suffix if len(suffix) == 9 else phone
+
+    script = f'''
+    tell application "Contacts"
+        set matchedPeople to (every person whose value of phones contains "{phone}")
+        if (count of matchedPeople) = 0 then
+            set matchedPeople to (every person whose value of phones contains "{local_fmt}")
+        end if
+        if (count of matchedPeople) > 0 then
+            set p to item 1 of matchedPeople
+            return (first name of p & " " & last name of p)
+        end if
+        return ""
+    end tell
+    '''
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True, text=True, timeout=5,
+        )
+        name = result.stdout.strip()
+        _CONTACT_CACHE[phone] = name if name else None
+        return _CONTACT_CACHE[phone]
+    except Exception:
+        _CONTACT_CACHE[phone] = None
+        return None
+
+
+# Path pattern for the NoteStore.sqlite database.
+_NOTESTORE_GLOB = os.path.expanduser(
+    "~/Library/Group Containers/group.com.apple.notes/NoteStore.sqlite"
+)
+
+
+def _find_notestore_db():
+    """Locate the NoteStore.sqlite database file."""
+    matches = glob.glob(_NOTESTORE_GLOB)
+    return matches[0] if matches else _NOTESTORE_GLOB
+
+
+def _extract_transcript_from_db(note_id):
+    """Extract transcript text from NoteStore.sqlite.
+
+    Apple stores call recording transcripts in the ZICCLOUDSYNCINGOBJECT
+    table, specifically in the ``ZMERGEABLEDATA1`` column of the
+    *attachment* record (the M4A audio), not the note record itself.
+
+    The data is an Apple CRDT protobuf blob with alternating UUID,
+    speaker phone number, and text segments.
+
+    Returns the formatted transcript text or None.
+    """
+    db_path = _find_notestore_db()
+
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    except sqlite3.OperationalError:
+        return None
+
+    try:
+        # The note_id looks like: x-coredata://UUID/ICNote/pNNN
+        note_pk = note_id.rsplit("/p", 1)[-1] if "/p" in note_id else None
+        if not note_pk:
+            return None
+
+        # Get ZMERGEABLEDATA1 from the attachment record linked to the note.
+        cursor = conn.execute(
+            """
+            SELECT ZMERGEABLEDATA1
+            FROM ZICCLOUDSYNCINGOBJECT
+            WHERE ZNOTE = ? AND ZMERGEABLEDATA1 IS NOT NULL
+            LIMIT 1
+            """,
+            (int(note_pk),),
+        )
+        row = cursor.fetchone()
+        if not row or not row[0]:
+            return None
+
+        return _parse_crdt_transcript(row[0])
+    except Exception:
+        return None
+    finally:
+        conn.close()
+
+
+# ── CRArchive protobuf decoder ──────────────────────────────────────
+#
+# Apple stores call recording transcripts in ZMERGEABLEDATA1 as a
+# CRArchive – an NSKeyedArchiver-like container built on protobuf.
+# The archive has:
+#   - object[]   (field 3)  – list of CRDT objects
+#   - keyItem[]  (field 4)  – string keys for custom objects
+#   - typeItem[] (field 5)  – type names (e.g. "com.apple.notes.ICTTTranscriptSegment")
+#   - uuidItem[] (field 6)  – byte UUIDs
+#
+# Each object is one of: registerLatest, dictionary, string,
+# custom (key-value with typed references), or orderedSet.
+#
+# The root object (object[0]) is an ICTTAudioRecording with keys:
+#   callLocalSpeakerHandle, callRemoteSpeakerHandle, fragments, etc.
+#
+# Transcript segments are ICTTTranscriptSegment custom objects with:
+#   speaker → NSString, text → NSString, timestamp → NSNumber.
+
+
+def _uvarint(data, pos):
+    """Decode an unsigned varint at *pos*, returning (value, new_pos)."""
+    x = s = 0
+    while True:
+        b = data[pos]
+        pos += 1
+        x |= (b & 0x7F) << s
+        if not (b & 0x80):
+            return x, pos
+        s += 7
+
+
+def _readbytes(data, pos):
+    length, pos = _uvarint(data, pos)
+    return data[pos : pos + length], pos + length
+
+
+def _readfixed(fmt, size):
+    import struct as _struct
+
+    return lambda data, pos: (_struct.unpack_from(fmt, data, pos)[0], pos + size)
+
+
+_READERS = [
+    _uvarint,            # 0: varint
+    _readfixed("<d", 8), # 1: 64-bit
+    _readbytes,          # 2: length-delimited
+    None,                # 3: start group (unused)
+    None,                # 4: end group (unused)
+    _readfixed("<f", 4), # 5: 32-bit
+]
+
+
+def _parse_protobuf(data, schema):
+    """Parse *data* using a schema dict.
+
+    Schema format per field:
+        field_number: ["name", is_repeated, sub_schema_or_type]
+    where sub_schema_or_type is a nested dict (sub-message), ``"string"``
+    (decode bytes as UTF-8), ``"bytes"`` (leave raw), or ``0`` (varint /
+    float – keep as-is).
+    """
+    obj = {}
+    pos = 0
+    while pos < len(data):
+        tag, pos = _uvarint(data, pos)
+        wire_type = tag & 7
+        field_num = tag >> 3
+        if wire_type >= len(_READERS) or _READERS[wire_type] is None:
+            break
+        val, pos = _READERS[wire_type](data, pos)
+        if field_num not in schema:
+            continue
+        name, repeated, typ = schema[field_num]
+        if isinstance(typ, dict):
+            val = _parse_protobuf(val, typ)
+        elif typ == "string":
+            val = val.decode("utf-8")
+        if repeated:
+            val = obj.get(name, []) + [val]
+        obj[name] = val
+    return obj
+
+
+# ── Protobuf schemas for the CRArchive ─────────────────────────────
+
+_S_OBJECTID = {
+    2: ["unsignedIntegerValue", 0, 0],
+    3: ["doubleValue", 0, 0],  # fixed64 – for NSNumber timestamps
+    4: ["stringValue", 0, "string"],
+    6: ["objectIndex", 0, 0],
+}
+
+_S_CUSTOM = {
+    1: ["type", 0, 0],
+    3: ["mapEntry", 1, {1: ["key", 0, 0], 2: ["value", 0, _S_OBJECTID]}],
+}
+
+_S_DICT = {
+    1: ["element", 1, {
+        1: ["key", 0, _S_OBJECTID],
+        2: ["value", 0, _S_OBJECTID],
+    }],
+}
+
+_S_STRING = {2: ["string", 0, "string"]}
+
+_S_DOCOBJ = {
+    1: ["registerLatest", 0, {2: ["contents", 0, _S_OBJECTID]}],
+    6: ["dictionary", 0, _S_DICT],
+    10: ["string", 0, _S_STRING],
+    13: ["custom", 0, _S_CUSTOM],
+}
+
+_S_CRARCHIVE = {
+    3: ["object", 1, _S_DOCOBJ],
+    4: ["keyItem", 1, "string"],
+    5: ["typeItem", 1, "string"],
+    6: ["uuidItem", 1, "bytes"],
+}
+
+
+def _parse_crdt_transcript(data):
+    """Parse a call recording transcript from a CRDT protobuf blob.
+
+    Decodes the CRArchive structure, walks the object graph to extract
+    ICTTTranscriptSegment entries, and assembles them into a formatted
+    transcript with "You" / "Participant" speaker labels.
+
+    Returns the formatted transcript as a string, or None.
+    """
+    try:
+        archive = _parse_protobuf(data, _S_CRARCHIVE)
+    except Exception:
+        return None
+
+    objects = archive.get("object", [])
+    key_items = archive.get("keyItem", [])
+    type_items = archive.get("typeItem", [])
+
+    if not objects or not key_items or not type_items:
+        return None
+
+    # ── helpers for resolving object references ──
+
+    def _resolve_string(obj_idx):
+        """Follow registerLatest → NSString → self → stringValue."""
+        if obj_idx >= len(objects):
+            return None
+        obj = objects[obj_idx]
+        if "registerLatest" in obj:
+            c = obj["registerLatest"].get("contents", {})
+            if "objectIndex" in c:
+                return _resolve_string(c["objectIndex"])
+        if "custom" in obj:
+            for me in obj["custom"].get("mapEntry", []):
+                kn = key_items[me["key"]] if me["key"] < len(key_items) else ""
+                if kn == "self":
+                    if "stringValue" in me["value"]:
+                        return me["value"]["stringValue"]
+                    if "objectIndex" in me["value"]:
+                        return _resolve_string(me["value"]["objectIndex"])
+        if "string" in obj:
+            return obj["string"].get("string")
+        return None
+
+    def _resolve_number(obj_idx):
+        """Follow registerLatest → NSNumber → doubleValue chain."""
+        if obj_idx >= len(objects):
+            return None
+        obj = objects[obj_idx]
+        if "registerLatest" in obj:
+            c = obj["registerLatest"].get("contents", {})
+            if "objectIndex" in c:
+                return _resolve_number(c["objectIndex"])
+            if "unsignedIntegerValue" in c:
+                return c["unsignedIntegerValue"]
+            if "doubleValue" in c:
+                return c["doubleValue"]
+        if "custom" in obj:
+            for me in obj["custom"].get("mapEntry", []):
+                kn = (
+                    key_items[me["key"]]
+                    if me["key"] < len(key_items)
+                    else ""
+                )
+                if kn == "doubleValue":
+                    v = me["value"]
+                    if "objectIndex" in v:
+                        return _resolve_number(v["objectIndex"])
+                    if "doubleValue" in v:
+                        return v["doubleValue"]
+                if kn == "integerValue":
+                    v = me["value"]
+                    if "objectIndex" in v:
+                        return _resolve_number(v["objectIndex"])
+                    if "unsignedIntegerValue" in v:
+                        return v["unsignedIntegerValue"]
+        return None
+
+    def _root_map():
+        """Build {key_name: value_ref} for the root custom object."""
+        root = objects[0]
+        if "custom" not in root:
+            return {}
+        return {
+            key_items[e["key"]]: e["value"]
+            for e in root["custom"].get("mapEntry", [])
+            if e["key"] < len(key_items)
+        }
+
+    rmap = _root_map()
+
+    # Get speaker handles from root ICTTAudioRecording.
+    local_phone = (
+        _resolve_string(rmap["callLocalSpeakerHandle"]["objectIndex"])
+        if "callLocalSpeakerHandle" in rmap
+        and "objectIndex" in rmap["callLocalSpeakerHandle"]
+        else None
+    )
+    remote_phone = (
+        _resolve_string(rmap["callRemoteSpeakerHandle"]["objectIndex"])
+        if "callRemoteSpeakerHandle" in rmap
+        and "objectIndex" in rmap["callRemoteSpeakerHandle"]
+        else None
+    )
+
+    # ── collect transcript segments with timestamps ──
+
+    raw_segments = []  # list of (timestamp, speaker_label, text)
+    for obj in objects:
+        if "custom" not in obj:
+            continue
+        typ_idx = obj["custom"]["type"]
+        if typ_idx >= len(type_items):
+            continue
+        if "TranscriptSegment" not in type_items[typ_idx]:
+            continue
+
+        seg_map = {}
+        for e in obj["custom"].get("mapEntry", []):
+            if e["key"] < len(key_items):
+                seg_map[key_items[e["key"]]] = e["value"]
+
+        text = (
+            _resolve_string(seg_map["text"]["objectIndex"])
+            if "text" in seg_map and "objectIndex" in seg_map["text"]
+            else None
+        )
+        speaker = (
+            _resolve_string(seg_map["speaker"]["objectIndex"])
+            if "speaker" in seg_map and "objectIndex" in seg_map["speaker"]
+            else None
+        )
+        timestamp = (
+            _resolve_number(seg_map["timestamp"]["objectIndex"])
+            if "timestamp" in seg_map
+            and "objectIndex" in seg_map["timestamp"]
+            else None
+        )
+
+        if not text or not text.strip():
+            continue
+
+        # Resolve speaker to contact name or fallback label.
+        if speaker == local_phone:
+            label = _lookup_contact_name(local_phone) or "You"
+        elif speaker == remote_phone:
+            label = _lookup_contact_name(remote_phone) or "Participant"
+        else:
+            label = _lookup_contact_name(speaker) or speaker or "Unknown"
+
+        raw_segments.append((timestamp or 0, label, text.strip()))
+
+    if not raw_segments:
+        return None
+
+    # Sort by timestamp to get correct reading order.
+    raw_segments.sort(key=lambda s: s[0])
+
+    # ── merge consecutive same-speaker fragments ──
+
+    merged = []
+    prev_label = None
+    buffer = []
+    for _ts, label, text in raw_segments:
+        if label == prev_label:
+            buffer.append(text)
+        else:
+            if buffer:
+                merged.append(f"**{prev_label}**: {' '.join(buffer)}")
+            buffer = [text]
+            prev_label = label
+    if buffer:
+        merged.append(f"**{prev_label}**: {' '.join(buffer)}")
+
+    return "\n\n".join(merged) if merged else None
 
 
 def get_recording_transcript(note_id):
-    """Retrieve the transcript of a call recording as markdown.
+    """Retrieve the transcript of a call recording.
 
-    Apple auto-generates transcripts for call recordings and stores them
-    as the note body.  We reuse id_search_memo + md_converter to convert
-    the HTML body to clean markdown.
+    Apple stores transcripts in NoteStore.sqlite, NOT in the note body
+    (which only contains the title).  Accessing the database requires
+    Full Disk Access for the terminal application.
 
-    Returns (markdown_text, original_html, image_map) or None on error.
+    Returns (transcript_text, note_title) or None on error.
     """
-    result = id_search_memo(note_id)
-    if result.returncode != 0:
-        return None
-    return md_converter(result)
+    # Try SQLite-based extraction first (requires Full Disk Access).
+    transcript = _extract_transcript_from_db(note_id)
+
+    # Get the note title via AppleScript (always works).
+    title_script = f"""
+    tell application "Notes"
+        set n to first note whose id is "{note_id}"
+        return name of n
+    end tell
+    """
+    title_result = subprocess.run(
+        ["osascript", "-e", title_script], capture_output=True, text=True
+    )
+    title = title_result.stdout.strip() if title_result.returncode == 0 else "Unknown"
+
+    if transcript:
+        return (f"# {title}\n\n{transcript}", title)
+
+    # Fallback: transcript not accessible.
+    return None
 
 
 def get_recording_attachments(note_id):

--- a/src/memo_helpers/search_memo.py
+++ b/src/memo_helpers/search_memo.py
@@ -6,42 +6,71 @@ from memo_helpers.id_search_memo import id_search_memo
 from memo_helpers.md_converter import md_converter
 
 
+def _run_fzf(directory, label="Your Notes"):
+    """Run fzf in the given directory with a customizable border label."""
+    fzf_command = rf"""
+    fzf --style=full \
+        --border --padding=1,2 \
+        --border-label=' {label} ' --input-label=' Input ' --header-label=' File Type ' \
+        --preview='bat --style=plain --color=always {{}}' \
+        --preview-window=right:60%:wrap:cycle \
+        --bind='ctrl-d:preview-down,ctrl-u:preview-up' \
+        --bind='result:transform-list-label:
+            if [[ -z $FZF_QUERY ]]; then
+            echo " $FZF_MATCH_COUNT items "
+            else
+            echo " $FZF_MATCH_COUNT matches for [$FZF_QUERY] "
+            fi' \
+        --bind='focus:transform-preview-label:[[ -n {{}} ]] && printf " Previewing [%s] " {{}}' \
+        --bind='focus:+transform-header:file --brief {{}} || echo "No file selected"' \
+        --bind='ctrl-r:change-list-label( Reloading the list )+reload(sleep 2; git ls-files)' \
+        --color='border:#aaaaaa,label:#cccccc' \
+        --color='preview-border:#9999cc,preview-label:#ccccff' \
+        --color='list-border:#669966,list-label:#99cc99' \
+        --color='input-border:#996666,input-label:#ffcccc' \
+        --color='header-border:#6699cc,header-label:#99ccff'
+    """
+    subprocess.run(fzf_command, shell=True, cwd=directory)
+
+
+def _populate_temp_dir(tmpdirname, note_map_items):
+    """Write markdown files for each note into a temp directory."""
+    for note_id, note_title in note_map_items:
+        result = id_search_memo(note_id)
+        original_md = md_converter(result)[0]
+
+        safe_filename = note_title.replace("/", "-").replace("\\", "-")
+        file_path = os.path.join(tmpdirname, f"{safe_filename}.md")
+
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write(original_md)
+
+
 def fuzzy_notes():
     note_map, unique_notes = get_note()
     title_to_id = {title: note_id for (_, (note_id, title)) in note_map.items()}
 
     with tempfile.TemporaryDirectory() as tmpdirname:
-        for note_title in unique_notes:
-            note_id = title_to_id[note_title]
-            result = id_search_memo(note_id)
-            original_md = md_converter(result)[0]
+        items = [(title_to_id[t], t) for t in unique_notes]
+        _populate_temp_dir(tmpdirname, items)
+        _run_fzf(tmpdirname, label="Your Notes")
 
-            safe_filename = note_title.replace("/", "-").replace("\\", "-")
-            file_path = os.path.join(tmpdirname, f"{safe_filename}.md")
 
-            with open(file_path, "w", encoding="utf-8") as f:
-                f.write(original_md)
+def fuzzy_recordings():
+    from memo_helpers.get_recordings import get_recordings
 
-        fzf_command = r"""
-        fzf --style=full \
-            --border --padding=1,2 \
-            --border-label=' Your Notes ' --input-label=' Input ' --header-label=' File Type ' \
-            --preview='bat --style=plain --color=always {}' \
-            --preview-window=right:60%:wrap:cycle \
-            --bind='ctrl-d:preview-down,ctrl-u:preview-up' \
-            --bind='result:transform-list-label:
-                if [[ -z $FZF_QUERY ]]; then
-                echo " $FZF_MATCH_COUNT items "
-                else
-                echo " $FZF_MATCH_COUNT matches for [$FZF_QUERY] "
-                fi' \
-            --bind='focus:transform-preview-label:[[ -n {} ]] && printf " Previewing [%s] " {}' \
-            --bind='focus:+transform-header:file --brief {} || echo "No file selected"' \
-            --bind='ctrl-r:change-list-label( Reloading the list )+reload(sleep 2; git ls-files)' \
-            --color='border:#aaaaaa,label:#cccccc' \
-            --color='preview-border:#9999cc,preview-label:#ccccff' \
-            --color='list-border:#669966,list-label:#99cc99' \
-            --color='input-border:#996666,input-label:#ffcccc' \
-            --color='header-border:#6699cc,header-label:#99ccff'
-        """
-        subprocess.run(fzf_command, shell=True, cwd=tmpdirname)
+    recording_map, recordings_list = get_recordings()
+    if not recordings_list:
+        import click
+
+        click.secho("\nNo call recordings found.", fg="yellow")
+        return
+
+    title_to_id = {
+        title: note_id for (_, (note_id, title)) in recording_map.items()
+    }
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        items = [(title_to_id[t], t) for t in recordings_list]
+        _populate_temp_dir(tmpdirname, items)
+        _run_fzf(tmpdirname, label="Call Recordings")

--- a/tests/test_recordings.py
+++ b/tests/test_recordings.py
@@ -33,8 +33,7 @@ def test_recordings_view(mock_get_recordings, mock_transcript):
     mock_get_recordings.return_value = (FAKE_RECORDING_MAP, FAKE_RECORDINGS_LIST)
     mock_transcript.return_value = (
         "# Call with John\n\nHello, this is a test transcript.",
-        "<div>Call with John</div>",
-        {},
+        "Call with John",
     )
     runner = CliRunner()
     result = runner.invoke(cli, ["recordings", "--view", "1"])

--- a/tests/test_recordings.py
+++ b/tests/test_recordings.py
@@ -1,0 +1,157 @@
+from click.testing import CliRunner
+from memo.memo import cli
+from unittest.mock import patch, MagicMock
+
+FAKE_RECORDING_ID = "x-coredata://fake-recording-123"
+FAKE_RECORDING_TITLE = "Call Recordings - Call with John (March 24, 2026)"
+FAKE_RECORDING_MAP = {1: (FAKE_RECORDING_ID, FAKE_RECORDING_TITLE)}
+FAKE_RECORDINGS_LIST = [FAKE_RECORDING_TITLE]
+
+
+@patch("memo.memo.get_recordings")
+def test_recordings_list(mock_get_recordings):
+    mock_get_recordings.return_value = (FAKE_RECORDING_MAP, FAKE_RECORDINGS_LIST)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["recordings"])
+    assert result.exit_code == 0
+    assert "Your Call Recordings:" in result.output
+    assert FAKE_RECORDING_TITLE in result.output
+
+
+@patch("memo.memo.get_recordings")
+def test_recordings_list_empty(mock_get_recordings):
+    mock_get_recordings.return_value = ({}, [])
+    runner = CliRunner()
+    result = runner.invoke(cli, ["recordings"])
+    assert result.exit_code == 0
+    assert "No call recordings found" in result.output
+
+
+@patch("memo.memo.get_recording_transcript")
+@patch("memo.memo.get_recordings")
+def test_recordings_view(mock_get_recordings, mock_transcript):
+    mock_get_recordings.return_value = (FAKE_RECORDING_MAP, FAKE_RECORDINGS_LIST)
+    mock_transcript.return_value = (
+        "# Call with John\n\nHello, this is a test transcript.",
+        "<div>Call with John</div>",
+        {},
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["recordings", "--view", "1"])
+    assert result.exit_code == 0
+    assert "Call with John" in result.output
+    mock_transcript.assert_called_once_with(FAKE_RECORDING_ID)
+
+
+@patch("memo.memo.get_recordings")
+def test_recordings_view_invalid(mock_get_recordings):
+    mock_get_recordings.return_value = (FAKE_RECORDING_MAP, FAKE_RECORDINGS_LIST)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["recordings", "--view", "999"])
+    assert result.exit_code == 0
+    assert "not found" in result.output
+
+
+@patch("memo.memo.extract_recording_audio")
+@patch("memo.memo.get_recordings")
+def test_recordings_extract(mock_get_recordings, mock_extract):
+    mock_get_recordings.return_value = (FAKE_RECORDING_MAP, FAKE_RECORDINGS_LIST)
+    mock_extract.return_value = "/Users/test/Desktop/call.m4a"
+    runner = CliRunner()
+    result = runner.invoke(cli, ["recordings", "--extract", "1"])
+    assert result.exit_code == 0
+    assert "Audio extracted to" in result.output
+
+
+@patch("memo.memo.extract_recording_audio")
+@patch("memo.memo.get_recordings")
+def test_recordings_extract_with_output(mock_get_recordings, mock_extract):
+    mock_get_recordings.return_value = (FAKE_RECORDING_MAP, FAKE_RECORDINGS_LIST)
+    mock_extract.return_value = "/tmp/calls/call.m4a"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["recordings", "--extract", "1", "--output", "/tmp/calls"]
+    )
+    assert result.exit_code == 0
+    mock_extract.assert_called_once_with(FAKE_RECORDING_ID, "/tmp/calls")
+
+
+@patch("memo.memo.get_recordings")
+def test_recordings_extract_invalid(mock_get_recordings):
+    mock_get_recordings.return_value = (FAKE_RECORDING_MAP, FAKE_RECORDINGS_LIST)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["recordings", "--extract", "999"])
+    assert result.exit_code == 0
+    assert "not found" in result.output
+
+
+# --- Unit tests for get_recordings module ---
+
+
+@patch("memo_helpers.get_recordings.subprocess.run")
+def test_get_recordings_parses_output(mock_run):
+    mock_run.return_value = MagicMock(
+        returncode=0,
+        stdout="x-coredata://id1|Call Recordings - First Call (Jan 1)\nx-coredata://id2|Call Recordings - Second Call (Jan 2)\n",
+        stderr="",
+    )
+    from memo_helpers.get_recordings import get_recordings
+
+    recording_map, recordings_list = get_recordings()
+    assert len(recording_map) == 2
+    assert recording_map[1] == ("x-coredata://id1", "Call Recordings - First Call (Jan 1)")
+    assert recording_map[2] == ("x-coredata://id2", "Call Recordings - Second Call (Jan 2)")
+    assert len(recordings_list) == 2
+
+
+@patch("memo_helpers.get_recordings.subprocess.run")
+def test_get_recordings_empty(mock_run):
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    from memo_helpers.get_recordings import get_recordings
+
+    recording_map, recordings_list = get_recordings()
+    assert recording_map == {}
+    assert recordings_list == []
+
+
+@patch("memo_helpers.get_recordings.subprocess.run")
+def test_get_recordings_error(mock_run):
+    mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
+    from memo_helpers.get_recordings import get_recordings
+
+    recording_map, recordings_list = get_recordings()
+    assert recording_map == {}
+    assert recordings_list == []
+
+
+# --- Unit tests for recording_utils ---
+
+
+@patch("memo_helpers.recording_utils.subprocess.run")
+def test_get_recording_attachments(mock_run):
+    mock_run.return_value = MagicMock(
+        returncode=0,
+        stdout="1|call_recording.m4a|audio/x-m4a\n",
+        stderr="",
+    )
+    from memo_helpers.recording_utils import get_recording_attachments
+
+    attachments = get_recording_attachments("fake-id")
+    assert len(attachments) == 1
+    assert attachments[0]["name"] == "call_recording.m4a"
+    assert attachments[0]["content_id"] == "audio/x-m4a"
+
+
+@patch("memo_helpers.recording_utils.os.path.exists", return_value=True)
+@patch("memo_helpers.recording_utils.subprocess.run")
+def test_extract_recording_audio(mock_run, mock_exists):
+    # First call returns the attachment name, second call does the save.
+    mock_run.side_effect = [
+        MagicMock(returncode=0, stdout="call_recording.m4a", stderr=""),
+        MagicMock(returncode=0, stdout="", stderr=""),
+    ]
+    from memo_helpers.recording_utils import extract_recording_audio
+
+    result = extract_recording_audio("fake-id", "/tmp/output")
+    assert result is not None
+    assert mock_run.call_count == 2

--- a/tests/test_transcript_parsing.py
+++ b/tests/test_transcript_parsing.py
@@ -1,0 +1,147 @@
+"""Regression tests for Apple Notes call recording transcript parsing.
+
+Uses a real CRDT blob fixture to validate that _parse_crdt_transcript
+produces correct transcripts with proper word ordering, speaker
+assignment, and formatting.
+
+The fixture file (tests/fixtures/recording2_crdt.bin) is gitignored
+because it contains private call recording data.  Tests are skipped
+when the fixture is absent (e.g. in CI).
+"""
+
+import os
+import re
+from unittest.mock import patch
+
+import pytest
+
+FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "fixtures", "recording2_crdt.bin"
+)
+
+# Skip the entire module if the fixture is missing (CI environments).
+pytestmark = pytest.mark.skipif(
+    not os.path.exists(FIXTURE_PATH),
+    reason="CRDT fixture not available (gitignored, local-only)",
+)
+
+
+@pytest.fixture
+def crdt_blob():
+    with open(FIXTURE_PATH, "rb") as f:
+        return f.read()
+
+
+@pytest.fixture
+def transcript(crdt_blob):
+    """Parse the CRDT blob with contact lookup disabled."""
+    with patch(
+        "memo_helpers.recording_utils._lookup_contact_name",
+        return_value=None,
+    ):
+        from memo_helpers.recording_utils import _parse_crdt_transcript
+
+        return _parse_crdt_transcript(crdt_blob)
+
+
+class TestCRDTTranscriptParsing:
+    def test_returns_transcript(self, transcript):
+        assert transcript is not None
+        assert len(transcript) > 100
+
+    def test_has_both_speakers(self, transcript):
+        """Both You and Participant labels should be present."""
+        assert "**Participant**:" in transcript
+        assert "**You**:" in transcript
+
+    def test_participant_speaks_first(self, transcript):
+        """Participant should speak the opening line."""
+        first_line = transcript.strip().split("\n")[0]
+        assert first_line.startswith("**Participant**:")
+
+    def test_speaker_turns_alternate(self, transcript):
+        """Speaker labels should alternate (no two consecutive same-speaker)."""
+        lines = [
+            l.strip() for l in transcript.split("\n") if l.strip()
+        ]
+        prev = None
+        for line in lines:
+            match = re.match(r"\*\*(.+?)\*\*:", line)
+            assert match, f"Line missing speaker label: {line[:60]}"
+            current = match.group(1)
+            assert current != prev, (
+                f"Consecutive same-speaker: {current}"
+            )
+            prev = current
+
+    def test_you_has_short_responses(self, transcript):
+        """'You' speaker should have characteristically short responses."""
+        lines = [
+            l.strip() for l in transcript.split("\n") if l.strip()
+        ]
+        you_lines = [l for l in lines if l.startswith("**You**:")]
+        assert len(you_lines) > 0
+        # At least half of You's responses should be short (< 50 chars).
+        short = sum(
+            1 for l in you_lines if len(l) - len("**You**: ") < 50
+        )
+        assert short >= len(you_lines) // 2
+
+    def test_no_binary_garbage(self, transcript):
+        """No binary noise, float artifacts, or CRDT metadata."""
+        assert "com.apple." not in transcript
+        assert "CRDT" not in transcript
+        assert "\ufffc" not in transcript
+        # No standalone float artifacts (e.g. "3.14159265").
+        floats = re.findall(r"\b\d+\.\d{4,}\b", transcript)
+        assert not floats, f"Float artifacts found: {floats}"
+
+    def test_minimum_turn_count(self, transcript):
+        """Should have a reasonable number of speaker turns."""
+        lines = [
+            l.strip() for l in transcript.split("\n") if l.strip()
+        ]
+        assert len(lines) >= 10, (
+            f"Only {len(lines)} turns — expected at least 10"
+        )
+
+    def test_words_form_sentences(self, transcript):
+        """Merged fragments should form multi-word sentences, not
+        single-word garbage."""
+        lines = [
+            l.strip() for l in transcript.split("\n") if l.strip()
+        ]
+        multi_word = sum(
+            1 for l in lines if len(l.split()) > 3
+        )
+        # At least a third of lines should be multi-word.
+        assert multi_word >= len(lines) // 3
+
+
+class TestCRDTTranscriptWithContactNames:
+    """Test that contact names replace default labels when available."""
+
+    def test_contact_names_replace_labels(self, crdt_blob):
+        names = {}
+
+        def mock_lookup(phone):
+            if phone and phone not in names:
+                names[phone] = f"Contact_{len(names) + 1}"
+            return names.get(phone)
+
+        with patch(
+            "memo_helpers.recording_utils._lookup_contact_name",
+            side_effect=mock_lookup,
+        ):
+            from memo_helpers.recording_utils import (
+                _parse_crdt_transcript,
+            )
+
+            transcript = _parse_crdt_transcript(crdt_blob)
+
+        assert transcript is not None
+        # Default labels should NOT appear when contacts resolve.
+        assert "**You**:" not in transcript
+        assert "**Participant**:" not in transcript
+        # Contact names should be used instead.
+        assert "**Contact_" in transcript

--- a/uv.lock
+++ b/uv.lock
@@ -1,14 +1,14 @@
 version = 1
-revision = 3
+revision = 1
 requires-python = ">=3.13"
 
 [[package]]
 name = "chardet"
 version = "5.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload-time = "2023-08-01T19:23:02.662Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload-time = "2023-08-01T19:23:00.661Z" },
+    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385 },
 ]
 
 [[package]]
@@ -18,128 +18,128 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274 },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
 ]
 
 [[package]]
 name = "coverage"
 version = "7.13.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/56/95b7e30fa389756cb56630faa728da46a27b8c6eb46f9d557c68fff12b65/coverage-7.13.4.tar.gz", hash = "sha256:e5c8f6ed1e61a8b2dcdf31eb0b9bbf0130750ca79c1c49eb898e2ad86f5ccc91", size = 827239, upload-time = "2026-02-09T12:59:03.86Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/56/95b7e30fa389756cb56630faa728da46a27b8c6eb46f9d557c68fff12b65/coverage-7.13.4.tar.gz", hash = "sha256:e5c8f6ed1e61a8b2dcdf31eb0b9bbf0130750ca79c1c49eb898e2ad86f5ccc91", size = 827239 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/23/aad45061a31677d68e47499197a131eea55da4875d16c1f42021ab963503/coverage-7.13.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b66a2da594b6068b48b2692f043f35d4d3693fb639d5ea8b39533c2ad9ac3ab9", size = 219474, upload-time = "2026-02-09T12:57:19.332Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/70/9b8b67a0945f3dfec1fd896c5cefb7c19d5a3a6d74630b99a895170999ae/coverage-7.13.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3599eb3992d814d23b35c536c28df1a882caa950f8f507cef23d1cbf334995ac", size = 219844, upload-time = "2026-02-09T12:57:20.66Z" },
-    { url = "https://files.pythonhosted.org/packages/97/fd/7e859f8fab324cef6c4ad7cff156ca7c489fef9179d5749b0c8d321281c2/coverage-7.13.4-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:93550784d9281e374fb5a12bf1324cc8a963fd63b2d2f223503ef0fd4aa339ea", size = 250832, upload-time = "2026-02-09T12:57:22.007Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/dc/b2442d10020c2f52617828862d8b6ee337859cd8f3a1f13d607dddda9cf7/coverage-7.13.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b720ce6a88a2755f7c697c23268ddc47a571b88052e6b155224347389fdf6a3b", size = 253434, upload-time = "2026-02-09T12:57:23.339Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/88/6728a7ad17428b18d836540630487231f5470fb82454871149502f5e5aa2/coverage-7.13.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7b322db1284a2ed3aa28ffd8ebe3db91c929b7a333c0820abec3d838ef5b3525", size = 254676, upload-time = "2026-02-09T12:57:24.774Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/bc/21244b1b8cedf0dff0a2b53b208015fe798d5f2a8d5348dbfece04224fff/coverage-7.13.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f4594c67d8a7c89cf922d9df0438c7c7bb022ad506eddb0fdb2863359ff78242", size = 256807, upload-time = "2026-02-09T12:57:26.125Z" },
-    { url = "https://files.pythonhosted.org/packages/97/a0/ddba7ed3251cff51006737a727d84e05b61517d1784a9988a846ba508877/coverage-7.13.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:53d133df809c743eb8bce33b24bcababb371f4441340578cd406e084d94a6148", size = 251058, upload-time = "2026-02-09T12:57:27.614Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/55/e289addf7ff54d3a540526f33751951bf0878f3809b47f6dfb3def69c6f7/coverage-7.13.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76451d1978b95ba6507a039090ba076105c87cc76fc3efd5d35d72093964d49a", size = 252805, upload-time = "2026-02-09T12:57:29.066Z" },
-    { url = "https://files.pythonhosted.org/packages/13/4e/cc276b1fa4a59be56d96f1dabddbdc30f4ba22e3b1cd42504c37b3313255/coverage-7.13.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7f57b33491e281e962021de110b451ab8a24182589be17e12a22c79047935e23", size = 250766, upload-time = "2026-02-09T12:57:30.522Z" },
-    { url = "https://files.pythonhosted.org/packages/94/44/1093b8f93018f8b41a8cf29636c9292502f05e4a113d4d107d14a3acd044/coverage-7.13.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1731dc33dc276dafc410a885cbf5992f1ff171393e48a21453b78727d090de80", size = 254923, upload-time = "2026-02-09T12:57:31.946Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/55/ea2796da2d42257f37dbea1aab239ba9263b31bd91d5527cdd6db5efe174/coverage-7.13.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:bd60d4fe2f6fa7dff9223ca1bbc9f05d2b6697bc5961072e5d3b952d46e1b1ea", size = 250591, upload-time = "2026-02-09T12:57:33.842Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/fa/7c4bb72aacf8af5020675aa633e59c1fbe296d22aed191b6a5b711eb2bc7/coverage-7.13.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9181a3ccead280b828fae232df12b16652702b49d41e99d657f46cc7b1f6ec7a", size = 252364, upload-time = "2026-02-09T12:57:35.743Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/38/a8d2ec0146479c20bbaa7181b5b455a0c41101eed57f10dd19a78ab44c80/coverage-7.13.4-cp313-cp313-win32.whl", hash = "sha256:f53d492307962561ac7de4cd1de3e363589b000ab69617c6156a16ba7237998d", size = 222010, upload-time = "2026-02-09T12:57:37.25Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/0c/dbfafbe90a185943dcfbc766fe0e1909f658811492d79b741523a414a6cc/coverage-7.13.4-cp313-cp313-win_amd64.whl", hash = "sha256:e6f70dec1cc557e52df5306d051ef56003f74d56e9c4dd7ddb07e07ef32a84dd", size = 222818, upload-time = "2026-02-09T12:57:38.734Z" },
-    { url = "https://files.pythonhosted.org/packages/04/d1/934918a138c932c90d78301f45f677fb05c39a3112b96fd2c8e60503cdc7/coverage-7.13.4-cp313-cp313-win_arm64.whl", hash = "sha256:fb07dc5da7e849e2ad31a5d74e9bece81f30ecf5a42909d0a695f8bd1874d6af", size = 221438, upload-time = "2026-02-09T12:57:40.223Z" },
-    { url = "https://files.pythonhosted.org/packages/52/57/ee93ced533bcb3e6df961c0c6e42da2fc6addae53fb95b94a89b1e33ebd7/coverage-7.13.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:40d74da8e6c4b9ac18b15331c4b5ebc35a17069410cad462ad4f40dcd2d50c0d", size = 220165, upload-time = "2026-02-09T12:57:41.639Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/e0/969fc285a6fbdda49d91af278488d904dcd7651b2693872f0ff94e40e84a/coverage-7.13.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4223b4230a376138939a9173f1bdd6521994f2aff8047fae100d6d94d50c5a12", size = 220516, upload-time = "2026-02-09T12:57:44.215Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/b8/9531944e16267e2735a30a9641ff49671f07e8138ecf1ca13db9fd2560c7/coverage-7.13.4-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1d4be36a5114c499f9f1f9195e95ebf979460dbe2d88e6816ea202010ba1c34b", size = 261804, upload-time = "2026-02-09T12:57:45.989Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/f3/e63df6d500314a2a60390d1989240d5f27318a7a68fa30ad3806e2a9323e/coverage-7.13.4-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:200dea7d1e8095cc6e98cdabe3fd1d21ab17d3cee6dab00cadbb2fe35d9c15b9", size = 263885, upload-time = "2026-02-09T12:57:47.42Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/67/7654810de580e14b37670b60a09c599fa348e48312db5b216d730857ffe6/coverage-7.13.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8eb931ee8e6d8243e253e5ed7336deea6904369d2fd8ae6e43f68abbf167092", size = 266308, upload-time = "2026-02-09T12:57:49.345Z" },
-    { url = "https://files.pythonhosted.org/packages/37/6f/39d41eca0eab3cc82115953ad41c4e77935286c930e8fad15eaed1389d83/coverage-7.13.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:75eab1ebe4f2f64d9509b984f9314d4aa788540368218b858dad56dc8f3e5eb9", size = 267452, upload-time = "2026-02-09T12:57:50.811Z" },
-    { url = "https://files.pythonhosted.org/packages/50/6d/39c0fbb8fc5cd4d2090811e553c2108cf5112e882f82505ee7495349a6bf/coverage-7.13.4-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c35eb28c1d085eb7d8c9b3296567a1bebe03ce72962e932431b9a61f28facf26", size = 261057, upload-time = "2026-02-09T12:57:52.447Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/a2/60010c669df5fa603bb5a97fb75407e191a846510da70ac657eb696b7fce/coverage-7.13.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:eb88b316ec33760714a4720feb2816a3a59180fd58c1985012054fa7aebee4c2", size = 263875, upload-time = "2026-02-09T12:57:53.938Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d9/63b22a6bdbd17f1f96e9ed58604c2a6b0e72a9133e37d663bef185877cf6/coverage-7.13.4-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7d41eead3cc673cbd38a4417deb7fd0b4ca26954ff7dc6078e33f6ff97bed940", size = 261500, upload-time = "2026-02-09T12:57:56.012Z" },
-    { url = "https://files.pythonhosted.org/packages/70/bf/69f86ba1ad85bc3ad240e4c0e57a2e620fbc0e1645a47b5c62f0e941ad7f/coverage-7.13.4-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:fb26a934946a6afe0e326aebe0730cdff393a8bc0bbb65a2f41e30feddca399c", size = 265212, upload-time = "2026-02-09T12:57:57.5Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/f2/5f65a278a8c2148731831574c73e42f57204243d33bedaaf18fa79c5958f/coverage-7.13.4-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:dae88bc0fc77edaa65c14be099bd57ee140cf507e6bfdeea7938457ab387efb0", size = 260398, upload-time = "2026-02-09T12:57:59.027Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/80/6e8280a350ee9fea92f14b8357448a242dcaa243cb2c72ab0ca591f66c8c/coverage-7.13.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:845f352911777a8e722bfce168958214951e07e47e5d5d9744109fa5fe77f79b", size = 262584, upload-time = "2026-02-09T12:58:01.129Z" },
-    { url = "https://files.pythonhosted.org/packages/22/63/01ff182fc95f260b539590fb12c11ad3e21332c15f9799cb5e2386f71d9f/coverage-7.13.4-cp313-cp313t-win32.whl", hash = "sha256:2fa8d5f8de70688a28240de9e139fa16b153cc3cbb01c5f16d88d6505ebdadf9", size = 222688, upload-time = "2026-02-09T12:58:02.736Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/43/89de4ef5d3cd53b886afa114065f7e9d3707bdb3e5efae13535b46ae483d/coverage-7.13.4-cp313-cp313t-win_amd64.whl", hash = "sha256:9351229c8c8407645840edcc277f4a2d44814d1bc34a2128c11c2a031d45a5dd", size = 223746, upload-time = "2026-02-09T12:58:05.362Z" },
-    { url = "https://files.pythonhosted.org/packages/35/39/7cf0aa9a10d470a5309b38b289b9bb07ddeac5d61af9b664fe9775a4cb3e/coverage-7.13.4-cp313-cp313t-win_arm64.whl", hash = "sha256:30b8d0512f2dc8c8747557e8fb459d6176a2c9e5731e2b74d311c03b78451997", size = 222003, upload-time = "2026-02-09T12:58:06.952Z" },
-    { url = "https://files.pythonhosted.org/packages/92/11/a9cf762bb83386467737d32187756a42094927150c3e107df4cb078e8590/coverage-7.13.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:300deaee342f90696ed186e3a00c71b5b3d27bffe9e827677954f4ee56969601", size = 219522, upload-time = "2026-02-09T12:58:08.623Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/28/56e6d892b7b052236d67c95f1936b6a7cf7c3e2634bf27610b8cbd7f9c60/coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29e3220258d682b6226a9b0925bc563ed9a1ebcff3cad30f043eceea7eaf2689", size = 219855, upload-time = "2026-02-09T12:58:10.176Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/69/233459ee9eb0c0d10fcc2fe425a029b3fa5ce0f040c966ebce851d030c70/coverage-7.13.4-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:391ee8f19bef69210978363ca930f7328081c6a0152f1166c91f0b5fdd2a773c", size = 250887, upload-time = "2026-02-09T12:58:12.503Z" },
-    { url = "https://files.pythonhosted.org/packages/06/90/2cdab0974b9b5bbc1623f7876b73603aecac11b8d95b85b5b86b32de5eab/coverage-7.13.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0dd7ab8278f0d58a0128ba2fca25824321f05d059c1441800e934ff2efa52129", size = 253396, upload-time = "2026-02-09T12:58:14.615Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/15/ea4da0f85bf7d7b27635039e649e99deb8173fe551096ea15017f7053537/coverage-7.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78cdf0d578b15148b009ccf18c686aa4f719d887e76e6b40c38ffb61d264a552", size = 254745, upload-time = "2026-02-09T12:58:16.162Z" },
-    { url = "https://files.pythonhosted.org/packages/99/11/bb356e86920c655ca4d61daee4e2bbc7258f0a37de0be32d233b561134ff/coverage-7.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:48685fee12c2eb3b27c62f2658e7ea21e9c3239cba5a8a242801a0a3f6a8c62a", size = 257055, upload-time = "2026-02-09T12:58:17.892Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/0f/9ae1f8cb17029e09da06ca4e28c9e1d5c1c0a511c7074592e37e0836c915/coverage-7.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4e83efc079eb39480e6346a15a1bcb3e9b04759c5202d157e1dd4303cd619356", size = 250911, upload-time = "2026-02-09T12:58:19.495Z" },
-    { url = "https://files.pythonhosted.org/packages/89/3a/adfb68558fa815cbc29747b553bc833d2150228f251b127f1ce97e48547c/coverage-7.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecae9737b72408d6a950f7e525f30aca12d4bd8dd95e37342e5beb3a2a8c4f71", size = 252754, upload-time = "2026-02-09T12:58:21.064Z" },
-    { url = "https://files.pythonhosted.org/packages/32/b1/540d0c27c4e748bd3cd0bd001076ee416eda993c2bae47a73b7cc9357931/coverage-7.13.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ae4578f8528569d3cf303fef2ea569c7f4c4059a38c8667ccef15c6e1f118aa5", size = 250720, upload-time = "2026-02-09T12:58:22.622Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/95/383609462b3ffb1fe133014a7c84fc0dd01ed55ac6140fa1093b5af7ebb1/coverage-7.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:6fdef321fdfbb30a197efa02d48fcd9981f0d8ad2ae8903ac318adc653f5df98", size = 254994, upload-time = "2026-02-09T12:58:24.548Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/ba/1761138e86c81680bfc3c49579d66312865457f9fe405b033184e5793cb3/coverage-7.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b0f6ccf3dbe577170bebfce1318707d0e8c3650003cb4b3a9dd744575daa8b5", size = 250531, upload-time = "2026-02-09T12:58:26.271Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/8e/05900df797a9c11837ab59c4d6fe94094e029582aab75c3309a93e6fb4e3/coverage-7.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75fcd519f2a5765db3f0e391eb3b7d150cce1a771bf4c9f861aeab86c767a3c0", size = 252189, upload-time = "2026-02-09T12:58:27.807Z" },
-    { url = "https://files.pythonhosted.org/packages/00/bd/29c9f2db9ea4ed2738b8a9508c35626eb205d51af4ab7bf56a21a2e49926/coverage-7.13.4-cp314-cp314-win32.whl", hash = "sha256:8e798c266c378da2bd819b0677df41ab46d78065fb2a399558f3f6cae78b2fbb", size = 222258, upload-time = "2026-02-09T12:58:29.441Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/4d/1f8e723f6829977410efeb88f73673d794075091c8c7c18848d273dc9d73/coverage-7.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:245e37f664d89861cf2329c9afa2c1fe9e6d4e1a09d872c947e70718aeeac505", size = 223073, upload-time = "2026-02-09T12:58:31.026Z" },
-    { url = "https://files.pythonhosted.org/packages/51/5b/84100025be913b44e082ea32abcf1afbf4e872f5120b7a1cab1d331b1e13/coverage-7.13.4-cp314-cp314-win_arm64.whl", hash = "sha256:ad27098a189e5838900ce4c2a99f2fe42a0bf0c2093c17c69b45a71579e8d4a2", size = 221638, upload-time = "2026-02-09T12:58:32.599Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/e4/c884a405d6ead1370433dad1e3720216b4f9fd8ef5b64bfd984a2a60a11a/coverage-7.13.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:85480adfb35ffc32d40918aad81b89c69c9cc5661a9b8a81476d3e645321a056", size = 220246, upload-time = "2026-02-09T12:58:34.181Z" },
-    { url = "https://files.pythonhosted.org/packages/81/5c/4d7ed8b23b233b0fffbc9dfec53c232be2e695468523242ea9fd30f97ad2/coverage-7.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79be69cf7f3bf9b0deeeb062eab7ac7f36cd4cc4c4dd694bd28921ba4d8596cc", size = 220514, upload-time = "2026-02-09T12:58:35.704Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/6f/3284d4203fd2f28edd73034968398cd2d4cb04ab192abc8cff007ea35679/coverage-7.13.4-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:caa421e2684e382c5d8973ac55e4f36bed6821a9bad5c953494de960c74595c9", size = 261877, upload-time = "2026-02-09T12:58:37.864Z" },
-    { url = "https://files.pythonhosted.org/packages/09/aa/b672a647bbe1556a85337dc95bfd40d146e9965ead9cc2fe81bde1e5cbce/coverage-7.13.4-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14375934243ee05f56c45393fe2ce81fe5cc503c07cee2bdf1725fb8bef3ffaf", size = 264004, upload-time = "2026-02-09T12:58:39.492Z" },
-    { url = "https://files.pythonhosted.org/packages/79/a1/aa384dbe9181f98bba87dd23dda436f0c6cf2e148aecbb4e50fc51c1a656/coverage-7.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25a41c3104d08edb094d9db0d905ca54d0cd41c928bb6be3c4c799a54753af55", size = 266408, upload-time = "2026-02-09T12:58:41.852Z" },
-    { url = "https://files.pythonhosted.org/packages/53/5e/5150bf17b4019bc600799f376bb9606941e55bd5a775dc1e096b6ffea952/coverage-7.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f01afcff62bf9a08fb32b2c1d6e924236c0383c02c790732b6537269e466a72", size = 267544, upload-time = "2026-02-09T12:58:44.093Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/ed/f1de5c675987a4a7a672250d2c5c9d73d289dbf13410f00ed7181d8017dd/coverage-7.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eb9078108fbf0bcdde37c3f4779303673c2fa1fe8f7956e68d447d0dd426d38a", size = 260980, upload-time = "2026-02-09T12:58:45.721Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/e3/fe758d01850aa172419a6743fe76ba8b92c29d181d4f676ffe2dae2ba631/coverage-7.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e086334e8537ddd17e5f16a344777c1ab8194986ec533711cbe6c41cde841b6", size = 263871, upload-time = "2026-02-09T12:58:47.334Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/76/b829869d464115e22499541def9796b25312b8cf235d3bb00b39f1675395/coverage-7.13.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:725d985c5ab621268b2edb8e50dfe57633dc69bda071abc470fed55a14935fd3", size = 261472, upload-time = "2026-02-09T12:58:48.995Z" },
-    { url = "https://files.pythonhosted.org/packages/14/9e/caedb1679e73e2f6ad240173f55218488bfe043e38da577c4ec977489915/coverage-7.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:3c06f0f1337c667b971ca2f975523347e63ec5e500b9aa5882d91931cd3ef750", size = 265210, upload-time = "2026-02-09T12:58:51.178Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/10/0dd02cb009b16ede425b49ec344aba13a6ae1dc39600840ea6abcb085ac4/coverage-7.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:590c0ed4bf8e85f745e6b805b2e1c457b2e33d5255dd9729743165253bc9ad39", size = 260319, upload-time = "2026-02-09T12:58:53.081Z" },
-    { url = "https://files.pythonhosted.org/packages/92/8e/234d2c927af27c6d7a5ffad5bd2cf31634c46a477b4c7adfbfa66baf7ebb/coverage-7.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eb30bf180de3f632cd043322dad5751390e5385108b2807368997d1a92a509d0", size = 262638, upload-time = "2026-02-09T12:58:55.258Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/64/e5547c8ff6964e5965c35a480855911b61509cce544f4d442caa759a0702/coverage-7.13.4-cp314-cp314t-win32.whl", hash = "sha256:c4240e7eded42d131a2d2c4dec70374b781b043ddc79a9de4d55ca71f8e98aea", size = 223040, upload-time = "2026-02-09T12:58:56.936Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/96/38086d58a181aac86d503dfa9c47eb20715a79c3e3acbdf786e92e5c09a8/coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932", size = 224148, upload-time = "2026-02-09T12:58:58.645Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/72/8d10abd3740a0beb98c305e0c3faf454366221c0f37a8bcf8f60020bb65a/coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b", size = 222172, upload-time = "2026-02-09T12:59:00.396Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/4a/331fe2caf6799d591109bb9c08083080f6de90a823695d412a935622abb2/coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0", size = 211242, upload-time = "2026-02-09T12:59:02.032Z" },
+    { url = "https://files.pythonhosted.org/packages/db/23/aad45061a31677d68e47499197a131eea55da4875d16c1f42021ab963503/coverage-7.13.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b66a2da594b6068b48b2692f043f35d4d3693fb639d5ea8b39533c2ad9ac3ab9", size = 219474 },
+    { url = "https://files.pythonhosted.org/packages/a5/70/9b8b67a0945f3dfec1fd896c5cefb7c19d5a3a6d74630b99a895170999ae/coverage-7.13.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3599eb3992d814d23b35c536c28df1a882caa950f8f507cef23d1cbf334995ac", size = 219844 },
+    { url = "https://files.pythonhosted.org/packages/97/fd/7e859f8fab324cef6c4ad7cff156ca7c489fef9179d5749b0c8d321281c2/coverage-7.13.4-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:93550784d9281e374fb5a12bf1324cc8a963fd63b2d2f223503ef0fd4aa339ea", size = 250832 },
+    { url = "https://files.pythonhosted.org/packages/e4/dc/b2442d10020c2f52617828862d8b6ee337859cd8f3a1f13d607dddda9cf7/coverage-7.13.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b720ce6a88a2755f7c697c23268ddc47a571b88052e6b155224347389fdf6a3b", size = 253434 },
+    { url = "https://files.pythonhosted.org/packages/5a/88/6728a7ad17428b18d836540630487231f5470fb82454871149502f5e5aa2/coverage-7.13.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7b322db1284a2ed3aa28ffd8ebe3db91c929b7a333c0820abec3d838ef5b3525", size = 254676 },
+    { url = "https://files.pythonhosted.org/packages/7c/bc/21244b1b8cedf0dff0a2b53b208015fe798d5f2a8d5348dbfece04224fff/coverage-7.13.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f4594c67d8a7c89cf922d9df0438c7c7bb022ad506eddb0fdb2863359ff78242", size = 256807 },
+    { url = "https://files.pythonhosted.org/packages/97/a0/ddba7ed3251cff51006737a727d84e05b61517d1784a9988a846ba508877/coverage-7.13.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:53d133df809c743eb8bce33b24bcababb371f4441340578cd406e084d94a6148", size = 251058 },
+    { url = "https://files.pythonhosted.org/packages/9b/55/e289addf7ff54d3a540526f33751951bf0878f3809b47f6dfb3def69c6f7/coverage-7.13.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76451d1978b95ba6507a039090ba076105c87cc76fc3efd5d35d72093964d49a", size = 252805 },
+    { url = "https://files.pythonhosted.org/packages/13/4e/cc276b1fa4a59be56d96f1dabddbdc30f4ba22e3b1cd42504c37b3313255/coverage-7.13.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7f57b33491e281e962021de110b451ab8a24182589be17e12a22c79047935e23", size = 250766 },
+    { url = "https://files.pythonhosted.org/packages/94/44/1093b8f93018f8b41a8cf29636c9292502f05e4a113d4d107d14a3acd044/coverage-7.13.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1731dc33dc276dafc410a885cbf5992f1ff171393e48a21453b78727d090de80", size = 254923 },
+    { url = "https://files.pythonhosted.org/packages/8b/55/ea2796da2d42257f37dbea1aab239ba9263b31bd91d5527cdd6db5efe174/coverage-7.13.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:bd60d4fe2f6fa7dff9223ca1bbc9f05d2b6697bc5961072e5d3b952d46e1b1ea", size = 250591 },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/7c4bb72aacf8af5020675aa633e59c1fbe296d22aed191b6a5b711eb2bc7/coverage-7.13.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9181a3ccead280b828fae232df12b16652702b49d41e99d657f46cc7b1f6ec7a", size = 252364 },
+    { url = "https://files.pythonhosted.org/packages/5c/38/a8d2ec0146479c20bbaa7181b5b455a0c41101eed57f10dd19a78ab44c80/coverage-7.13.4-cp313-cp313-win32.whl", hash = "sha256:f53d492307962561ac7de4cd1de3e363589b000ab69617c6156a16ba7237998d", size = 222010 },
+    { url = "https://files.pythonhosted.org/packages/e2/0c/dbfafbe90a185943dcfbc766fe0e1909f658811492d79b741523a414a6cc/coverage-7.13.4-cp313-cp313-win_amd64.whl", hash = "sha256:e6f70dec1cc557e52df5306d051ef56003f74d56e9c4dd7ddb07e07ef32a84dd", size = 222818 },
+    { url = "https://files.pythonhosted.org/packages/04/d1/934918a138c932c90d78301f45f677fb05c39a3112b96fd2c8e60503cdc7/coverage-7.13.4-cp313-cp313-win_arm64.whl", hash = "sha256:fb07dc5da7e849e2ad31a5d74e9bece81f30ecf5a42909d0a695f8bd1874d6af", size = 221438 },
+    { url = "https://files.pythonhosted.org/packages/52/57/ee93ced533bcb3e6df961c0c6e42da2fc6addae53fb95b94a89b1e33ebd7/coverage-7.13.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:40d74da8e6c4b9ac18b15331c4b5ebc35a17069410cad462ad4f40dcd2d50c0d", size = 220165 },
+    { url = "https://files.pythonhosted.org/packages/c5/e0/969fc285a6fbdda49d91af278488d904dcd7651b2693872f0ff94e40e84a/coverage-7.13.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4223b4230a376138939a9173f1bdd6521994f2aff8047fae100d6d94d50c5a12", size = 220516 },
+    { url = "https://files.pythonhosted.org/packages/b1/b8/9531944e16267e2735a30a9641ff49671f07e8138ecf1ca13db9fd2560c7/coverage-7.13.4-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1d4be36a5114c499f9f1f9195e95ebf979460dbe2d88e6816ea202010ba1c34b", size = 261804 },
+    { url = "https://files.pythonhosted.org/packages/8a/f3/e63df6d500314a2a60390d1989240d5f27318a7a68fa30ad3806e2a9323e/coverage-7.13.4-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:200dea7d1e8095cc6e98cdabe3fd1d21ab17d3cee6dab00cadbb2fe35d9c15b9", size = 263885 },
+    { url = "https://files.pythonhosted.org/packages/f3/67/7654810de580e14b37670b60a09c599fa348e48312db5b216d730857ffe6/coverage-7.13.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8eb931ee8e6d8243e253e5ed7336deea6904369d2fd8ae6e43f68abbf167092", size = 266308 },
+    { url = "https://files.pythonhosted.org/packages/37/6f/39d41eca0eab3cc82115953ad41c4e77935286c930e8fad15eaed1389d83/coverage-7.13.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:75eab1ebe4f2f64d9509b984f9314d4aa788540368218b858dad56dc8f3e5eb9", size = 267452 },
+    { url = "https://files.pythonhosted.org/packages/50/6d/39c0fbb8fc5cd4d2090811e553c2108cf5112e882f82505ee7495349a6bf/coverage-7.13.4-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c35eb28c1d085eb7d8c9b3296567a1bebe03ce72962e932431b9a61f28facf26", size = 261057 },
+    { url = "https://files.pythonhosted.org/packages/a4/a2/60010c669df5fa603bb5a97fb75407e191a846510da70ac657eb696b7fce/coverage-7.13.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:eb88b316ec33760714a4720feb2816a3a59180fd58c1985012054fa7aebee4c2", size = 263875 },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/63b22a6bdbd17f1f96e9ed58604c2a6b0e72a9133e37d663bef185877cf6/coverage-7.13.4-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7d41eead3cc673cbd38a4417deb7fd0b4ca26954ff7dc6078e33f6ff97bed940", size = 261500 },
+    { url = "https://files.pythonhosted.org/packages/70/bf/69f86ba1ad85bc3ad240e4c0e57a2e620fbc0e1645a47b5c62f0e941ad7f/coverage-7.13.4-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:fb26a934946a6afe0e326aebe0730cdff393a8bc0bbb65a2f41e30feddca399c", size = 265212 },
+    { url = "https://files.pythonhosted.org/packages/ae/f2/5f65a278a8c2148731831574c73e42f57204243d33bedaaf18fa79c5958f/coverage-7.13.4-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:dae88bc0fc77edaa65c14be099bd57ee140cf507e6bfdeea7938457ab387efb0", size = 260398 },
+    { url = "https://files.pythonhosted.org/packages/ef/80/6e8280a350ee9fea92f14b8357448a242dcaa243cb2c72ab0ca591f66c8c/coverage-7.13.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:845f352911777a8e722bfce168958214951e07e47e5d5d9744109fa5fe77f79b", size = 262584 },
+    { url = "https://files.pythonhosted.org/packages/22/63/01ff182fc95f260b539590fb12c11ad3e21332c15f9799cb5e2386f71d9f/coverage-7.13.4-cp313-cp313t-win32.whl", hash = "sha256:2fa8d5f8de70688a28240de9e139fa16b153cc3cbb01c5f16d88d6505ebdadf9", size = 222688 },
+    { url = "https://files.pythonhosted.org/packages/a9/43/89de4ef5d3cd53b886afa114065f7e9d3707bdb3e5efae13535b46ae483d/coverage-7.13.4-cp313-cp313t-win_amd64.whl", hash = "sha256:9351229c8c8407645840edcc277f4a2d44814d1bc34a2128c11c2a031d45a5dd", size = 223746 },
+    { url = "https://files.pythonhosted.org/packages/35/39/7cf0aa9a10d470a5309b38b289b9bb07ddeac5d61af9b664fe9775a4cb3e/coverage-7.13.4-cp313-cp313t-win_arm64.whl", hash = "sha256:30b8d0512f2dc8c8747557e8fb459d6176a2c9e5731e2b74d311c03b78451997", size = 222003 },
+    { url = "https://files.pythonhosted.org/packages/92/11/a9cf762bb83386467737d32187756a42094927150c3e107df4cb078e8590/coverage-7.13.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:300deaee342f90696ed186e3a00c71b5b3d27bffe9e827677954f4ee56969601", size = 219522 },
+    { url = "https://files.pythonhosted.org/packages/d3/28/56e6d892b7b052236d67c95f1936b6a7cf7c3e2634bf27610b8cbd7f9c60/coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29e3220258d682b6226a9b0925bc563ed9a1ebcff3cad30f043eceea7eaf2689", size = 219855 },
+    { url = "https://files.pythonhosted.org/packages/e5/69/233459ee9eb0c0d10fcc2fe425a029b3fa5ce0f040c966ebce851d030c70/coverage-7.13.4-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:391ee8f19bef69210978363ca930f7328081c6a0152f1166c91f0b5fdd2a773c", size = 250887 },
+    { url = "https://files.pythonhosted.org/packages/06/90/2cdab0974b9b5bbc1623f7876b73603aecac11b8d95b85b5b86b32de5eab/coverage-7.13.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0dd7ab8278f0d58a0128ba2fca25824321f05d059c1441800e934ff2efa52129", size = 253396 },
+    { url = "https://files.pythonhosted.org/packages/ac/15/ea4da0f85bf7d7b27635039e649e99deb8173fe551096ea15017f7053537/coverage-7.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78cdf0d578b15148b009ccf18c686aa4f719d887e76e6b40c38ffb61d264a552", size = 254745 },
+    { url = "https://files.pythonhosted.org/packages/99/11/bb356e86920c655ca4d61daee4e2bbc7258f0a37de0be32d233b561134ff/coverage-7.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:48685fee12c2eb3b27c62f2658e7ea21e9c3239cba5a8a242801a0a3f6a8c62a", size = 257055 },
+    { url = "https://files.pythonhosted.org/packages/c9/0f/9ae1f8cb17029e09da06ca4e28c9e1d5c1c0a511c7074592e37e0836c915/coverage-7.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4e83efc079eb39480e6346a15a1bcb3e9b04759c5202d157e1dd4303cd619356", size = 250911 },
+    { url = "https://files.pythonhosted.org/packages/89/3a/adfb68558fa815cbc29747b553bc833d2150228f251b127f1ce97e48547c/coverage-7.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecae9737b72408d6a950f7e525f30aca12d4bd8dd95e37342e5beb3a2a8c4f71", size = 252754 },
+    { url = "https://files.pythonhosted.org/packages/32/b1/540d0c27c4e748bd3cd0bd001076ee416eda993c2bae47a73b7cc9357931/coverage-7.13.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ae4578f8528569d3cf303fef2ea569c7f4c4059a38c8667ccef15c6e1f118aa5", size = 250720 },
+    { url = "https://files.pythonhosted.org/packages/c7/95/383609462b3ffb1fe133014a7c84fc0dd01ed55ac6140fa1093b5af7ebb1/coverage-7.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:6fdef321fdfbb30a197efa02d48fcd9981f0d8ad2ae8903ac318adc653f5df98", size = 254994 },
+    { url = "https://files.pythonhosted.org/packages/f7/ba/1761138e86c81680bfc3c49579d66312865457f9fe405b033184e5793cb3/coverage-7.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b0f6ccf3dbe577170bebfce1318707d0e8c3650003cb4b3a9dd744575daa8b5", size = 250531 },
+    { url = "https://files.pythonhosted.org/packages/f8/8e/05900df797a9c11837ab59c4d6fe94094e029582aab75c3309a93e6fb4e3/coverage-7.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75fcd519f2a5765db3f0e391eb3b7d150cce1a771bf4c9f861aeab86c767a3c0", size = 252189 },
+    { url = "https://files.pythonhosted.org/packages/00/bd/29c9f2db9ea4ed2738b8a9508c35626eb205d51af4ab7bf56a21a2e49926/coverage-7.13.4-cp314-cp314-win32.whl", hash = "sha256:8e798c266c378da2bd819b0677df41ab46d78065fb2a399558f3f6cae78b2fbb", size = 222258 },
+    { url = "https://files.pythonhosted.org/packages/a7/4d/1f8e723f6829977410efeb88f73673d794075091c8c7c18848d273dc9d73/coverage-7.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:245e37f664d89861cf2329c9afa2c1fe9e6d4e1a09d872c947e70718aeeac505", size = 223073 },
+    { url = "https://files.pythonhosted.org/packages/51/5b/84100025be913b44e082ea32abcf1afbf4e872f5120b7a1cab1d331b1e13/coverage-7.13.4-cp314-cp314-win_arm64.whl", hash = "sha256:ad27098a189e5838900ce4c2a99f2fe42a0bf0c2093c17c69b45a71579e8d4a2", size = 221638 },
+    { url = "https://files.pythonhosted.org/packages/a7/e4/c884a405d6ead1370433dad1e3720216b4f9fd8ef5b64bfd984a2a60a11a/coverage-7.13.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:85480adfb35ffc32d40918aad81b89c69c9cc5661a9b8a81476d3e645321a056", size = 220246 },
+    { url = "https://files.pythonhosted.org/packages/81/5c/4d7ed8b23b233b0fffbc9dfec53c232be2e695468523242ea9fd30f97ad2/coverage-7.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79be69cf7f3bf9b0deeeb062eab7ac7f36cd4cc4c4dd694bd28921ba4d8596cc", size = 220514 },
+    { url = "https://files.pythonhosted.org/packages/2f/6f/3284d4203fd2f28edd73034968398cd2d4cb04ab192abc8cff007ea35679/coverage-7.13.4-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:caa421e2684e382c5d8973ac55e4f36bed6821a9bad5c953494de960c74595c9", size = 261877 },
+    { url = "https://files.pythonhosted.org/packages/09/aa/b672a647bbe1556a85337dc95bfd40d146e9965ead9cc2fe81bde1e5cbce/coverage-7.13.4-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14375934243ee05f56c45393fe2ce81fe5cc503c07cee2bdf1725fb8bef3ffaf", size = 264004 },
+    { url = "https://files.pythonhosted.org/packages/79/a1/aa384dbe9181f98bba87dd23dda436f0c6cf2e148aecbb4e50fc51c1a656/coverage-7.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25a41c3104d08edb094d9db0d905ca54d0cd41c928bb6be3c4c799a54753af55", size = 266408 },
+    { url = "https://files.pythonhosted.org/packages/53/5e/5150bf17b4019bc600799f376bb9606941e55bd5a775dc1e096b6ffea952/coverage-7.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f01afcff62bf9a08fb32b2c1d6e924236c0383c02c790732b6537269e466a72", size = 267544 },
+    { url = "https://files.pythonhosted.org/packages/e0/ed/f1de5c675987a4a7a672250d2c5c9d73d289dbf13410f00ed7181d8017dd/coverage-7.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eb9078108fbf0bcdde37c3f4779303673c2fa1fe8f7956e68d447d0dd426d38a", size = 260980 },
+    { url = "https://files.pythonhosted.org/packages/b3/e3/fe758d01850aa172419a6743fe76ba8b92c29d181d4f676ffe2dae2ba631/coverage-7.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e086334e8537ddd17e5f16a344777c1ab8194986ec533711cbe6c41cde841b6", size = 263871 },
+    { url = "https://files.pythonhosted.org/packages/b6/76/b829869d464115e22499541def9796b25312b8cf235d3bb00b39f1675395/coverage-7.13.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:725d985c5ab621268b2edb8e50dfe57633dc69bda071abc470fed55a14935fd3", size = 261472 },
+    { url = "https://files.pythonhosted.org/packages/14/9e/caedb1679e73e2f6ad240173f55218488bfe043e38da577c4ec977489915/coverage-7.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:3c06f0f1337c667b971ca2f975523347e63ec5e500b9aa5882d91931cd3ef750", size = 265210 },
+    { url = "https://files.pythonhosted.org/packages/3a/10/0dd02cb009b16ede425b49ec344aba13a6ae1dc39600840ea6abcb085ac4/coverage-7.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:590c0ed4bf8e85f745e6b805b2e1c457b2e33d5255dd9729743165253bc9ad39", size = 260319 },
+    { url = "https://files.pythonhosted.org/packages/92/8e/234d2c927af27c6d7a5ffad5bd2cf31634c46a477b4c7adfbfa66baf7ebb/coverage-7.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eb30bf180de3f632cd043322dad5751390e5385108b2807368997d1a92a509d0", size = 262638 },
+    { url = "https://files.pythonhosted.org/packages/2f/64/e5547c8ff6964e5965c35a480855911b61509cce544f4d442caa759a0702/coverage-7.13.4-cp314-cp314t-win32.whl", hash = "sha256:c4240e7eded42d131a2d2c4dec70374b781b043ddc79a9de4d55ca71f8e98aea", size = 223040 },
+    { url = "https://files.pythonhosted.org/packages/c7/96/38086d58a181aac86d503dfa9c47eb20715a79c3e3acbdf786e92e5c09a8/coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932", size = 224148 },
+    { url = "https://files.pythonhosted.org/packages/ce/72/8d10abd3740a0beb98c305e0c3faf454366221c0f37a8bcf8f60020bb65a/coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b", size = 222172 },
+    { url = "https://files.pythonhosted.org/packages/0d/4a/331fe2caf6799d591109bb9c08083080f6de90a823695d412a935622abb2/coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0", size = 211242 },
 ]
 
 [[package]]
 name = "deepmerge"
 version = "2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a8/3a/b0ba594708f1ad0bc735884b3ad854d3ca3bdc1d741e56e40bbda6263499/deepmerge-2.0.tar.gz", hash = "sha256:5c3d86081fbebd04dd5de03626a0607b809a98fb6ccba5770b62466fe940ff20", size = 19890, upload-time = "2024-08-30T05:31:50.308Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/3a/b0ba594708f1ad0bc735884b3ad854d3ca3bdc1d741e56e40bbda6263499/deepmerge-2.0.tar.gz", hash = "sha256:5c3d86081fbebd04dd5de03626a0607b809a98fb6ccba5770b62466fe940ff20", size = 19890 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/82/e5d2c1c67d19841e9edc74954c827444ae826978499bde3dfc1d007c8c11/deepmerge-2.0-py3-none-any.whl", hash = "sha256:6de9ce507115cff0bed95ff0ce9ecc31088ef50cbdf09bc90a09349a318b3d00", size = 13475, upload-time = "2024-08-30T05:31:48.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/82/e5d2c1c67d19841e9edc74954c827444ae826978499bde3dfc1d007c8c11/deepmerge-2.0-py3-none-any.whl", hash = "sha256:6de9ce507115cff0bed95ff0ce9ecc31088ef50cbdf09bc90a09349a318b3d00", size = 13475 },
 ]
 
 [[package]]
 name = "html2text"
 version = "2025.4.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/27/e158d86ba1e82967cc2f790b0cb02030d4a8bef58e0c79a8590e9678107f/html2text-2025.4.15.tar.gz", hash = "sha256:948a645f8f0bc3abe7fd587019a2197a12436cd73d0d4908af95bfc8da337588", size = 64316, upload-time = "2025-04-15T04:02:30.045Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/27/e158d86ba1e82967cc2f790b0cb02030d4a8bef58e0c79a8590e9678107f/html2text-2025.4.15.tar.gz", hash = "sha256:948a645f8f0bc3abe7fd587019a2197a12436cd73d0d4908af95bfc8da337588", size = 64316 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl", hash = "sha256:00569167ffdab3d7767a4cdf589b7f57e777a5ed28d12907d8c58769ec734acc", size = 34656, upload-time = "2025-04-15T04:02:28.44Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl", hash = "sha256:00569167ffdab3d7767a4cdf589b7f57e777a5ed28d12907d8c58769ec734acc", size = 34656 },
 ]
 
 [[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
 ]
 
 [[package]]
 name = "markdown"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/7dd27d9d863b3376fcf23a5a13cb5d024aed1db46f963f1b5735ae43b3be/markdown-3.10.tar.gz", hash = "sha256:37062d4f2aa4b2b6b32aefb80faa300f82cc790cb949a35b8caede34f2b68c0e", size = 364931, upload-time = "2025-11-03T19:51:15.007Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/7dd27d9d863b3376fcf23a5a13cb5d024aed1db46f963f1b5735ae43b3be/markdown-3.10.tar.gz", hash = "sha256:37062d4f2aa4b2b6b32aefb80faa300f82cc790cb949a35b8caede34f2b68c0e", size = 364931 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/81/54e3ce63502cd085a0c556652a4e1b919c45a446bd1e5300e10c44c8c521/markdown-3.10-py3-none-any.whl", hash = "sha256:b5b99d6951e2e4948d939255596523444c0e677c669700b1d17aa4a8a464cb7c", size = 107678, upload-time = "2025-11-03T19:51:13.887Z" },
+    { url = "https://files.pythonhosted.org/packages/70/81/54e3ce63502cd085a0c556652a4e1b919c45a446bd1e5300e10c44c8c521/markdown-3.10-py3-none-any.whl", hash = "sha256:b5b99d6951e2e4948d939255596523444c0e677c669700b1d17aa4a8a464cb7c", size = 107678 },
 ]
 
 [[package]]
 name = "memo"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },
@@ -178,36 +178,36 @@ dev = [
 name = "mistune"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/55/d01f0c4b45ade6536c51170b9043db8b2ec6ddf4a35c7ea3f5f559ac935b/mistune-3.2.0.tar.gz", hash = "sha256:708487c8a8cdd99c9d90eb3ed4c3ed961246ff78ac82f03418f5183ab70e398a", size = 95467, upload-time = "2025-12-23T11:36:34.994Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/55/d01f0c4b45ade6536c51170b9043db8b2ec6ddf4a35c7ea3f5f559ac935b/mistune-3.2.0.tar.gz", hash = "sha256:708487c8a8cdd99c9d90eb3ed4c3ed961246ff78ac82f03418f5183ab70e398a", size = 95467 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/f7/4a5e785ec9fbd65146a27b6b70b6cdc161a66f2024e4b04ac06a67f5578b/mistune-3.2.0-py3-none-any.whl", hash = "sha256:febdc629a3c78616b94393c6580551e0e34cc289987ec6c35ed3f4be42d0eee1", size = 53598, upload-time = "2025-12-23T11:36:33.211Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f7/4a5e785ec9fbd65146a27b6b70b6cdc161a66f2024e4b04ac06a67f5578b/mistune-3.2.0-py3-none-any.whl", hash = "sha256:febdc629a3c78616b94393c6580551e0e34cc289987ec6c35ed3f4be42d0eee1", size = 53598 },
 ]
 
 [[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
 ]
 
 [[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
 ]
 
 [[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217 },
 ]
 
 [[package]]
@@ -218,9 +218,9 @@ dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/35/e3814a5b7df295df69d035cfb8aab78b2967cdf11fcfae7faed726b66664/pymdown_extensions-10.20.tar.gz", hash = "sha256:5c73566ab0cf38c6ba084cb7c5ea64a119ae0500cce754ccb682761dfea13a52", size = 852774, upload-time = "2025-12-31T19:59:42.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/35/e3814a5b7df295df69d035cfb8aab78b2967cdf11fcfae7faed726b66664/pymdown_extensions-10.20.tar.gz", hash = "sha256:5c73566ab0cf38c6ba084cb7c5ea64a119ae0500cce754ccb682761dfea13a52", size = 852774 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/10/47caf89cbb52e5bb764696fd52a8c591a2f0e851a93270c05a17f36000b5/pymdown_extensions-10.20-py3-none-any.whl", hash = "sha256:ea9e62add865da80a271d00bfa1c0fa085b20d133fb3fc97afdc88e682f60b2f", size = 268733, upload-time = "2025-12-31T19:59:40.652Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/10/47caf89cbb52e5bb764696fd52a8c591a2f0e851a93270c05a17f36000b5/pymdown_extensions-10.20-py3-none-any.whl", hash = "sha256:ea9e62add865da80a271d00bfa1c0fa085b20d133fb3fc97afdc88e682f60b2f", size = 268733 },
 ]
 
 [[package]]
@@ -234,9 +234,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801 },
 ]
 
 [[package]]
@@ -246,9 +246,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075 },
 ]
 
 [[package]]
@@ -260,54 +260,54 @@ dependencies = [
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424 },
 ]
 
 [[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
-    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
-    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
-    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
-    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
-    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
-    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
-    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
-    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
-    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
-    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669 },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252 },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081 },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159 },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626 },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613 },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115 },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427 },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090 },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246 },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814 },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809 },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454 },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355 },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175 },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228 },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194 },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429 },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912 },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108 },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641 },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901 },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132 },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261 },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272 },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923 },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062 },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341 },
 ]
 
 [[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584 },
 ]
 
 [[package]]
@@ -322,18 +322,18 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/96/9c6cbdd7b351d1023cdbbcf7872d4cb118b0334cfe5821b99e0dd18e3f00/zensical-0.0.24.tar.gz", hash = "sha256:b5d99e225329bf4f98c8022bdf0a0ee9588c2fada7b4df1b7b896fcc62b37ec3", size = 3840688, upload-time = "2026-02-26T09:43:44.557Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/96/9c6cbdd7b351d1023cdbbcf7872d4cb118b0334cfe5821b99e0dd18e3f00/zensical-0.0.24.tar.gz", hash = "sha256:b5d99e225329bf4f98c8022bdf0a0ee9588c2fada7b4df1b7b896fcc62b37ec3", size = 3840688 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/aa/b8201af30e376a67566f044a1c56210edac5ae923fd986a836d2cf593c9c/zensical-0.0.24-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d390c5453a5541ca35d4f9e1796df942b6612c546e3153dd928236d3b758409a", size = 12263407, upload-time = "2026-02-26T09:43:14.716Z" },
-    { url = "https://files.pythonhosted.org/packages/78/8e/3d910214471ade604fd39b080db3696864acc23678b5b4b8475c7dbfd2ce/zensical-0.0.24-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:81ac072869cf4d280853765b2bfb688653da0dfb9408f3ab15aca96455ab8223", size = 12142610, upload-time = "2026-02-26T09:43:17.546Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/d7/eb0983640aa0419ddf670298cfbcf8b75629b6484925429b857851e00784/zensical-0.0.24-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5eb1dfa84cae8e960bfa2c6851d2bc8e9710c4c4c683bd3aaf23185f646ae46", size = 12508380, upload-time = "2026-02-26T09:43:20.114Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/04/4405b9e6f937a75db19f0d875798a7eb70817d6a3bec2a2d289a2d5e8aea/zensical-0.0.24-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:57d7c9e589da99c1879a1c703e67c85eaa6be4661cdc6ce6534f7bb3575983f4", size = 12440807, upload-time = "2026-02-26T09:43:22.679Z" },
-    { url = "https://files.pythonhosted.org/packages/12/dc/a7ca2a4224b3072a2c2998b6611ad7fd4f8f131ceae7aa23238d97d26e22/zensical-0.0.24-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:42fcc121c3095734b078a95a0dae4d4924fb8fbf16bf730456146ad6cab48ad0", size = 12782727, upload-time = "2026-02-26T09:43:25.347Z" },
-    { url = "https://files.pythonhosted.org/packages/42/37/22f1727da356ed3fcbd31f68d4a477f15c232997c87e270cfffb927459ac/zensical-0.0.24-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:832d4a2a051b9f49561031a2986ace502326f82d9a401ddf125530d30025fdd4", size = 12547616, upload-time = "2026-02-26T09:43:28.031Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/ff/c75ff111b8e12157901d00752beef9d691dbb5a034b6a77359972262416a/zensical-0.0.24-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e5fea3bb61238dba9f930f52669db67b0c26be98e1c8386a05eb2b1e3cb875dc", size = 12684883, upload-time = "2026-02-26T09:43:30.642Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/92/4f6ea066382e3d068d3cadbed99e9a71af25e46c84a403e0f747960472a2/zensical-0.0.24-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:75eef0428eec2958590633fdc82dc2a58af124879e29573aa7e153b662978073", size = 12713825, upload-time = "2026-02-26T09:43:33.273Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/fb/bf735b19bce0034b1f3b8e1c50b2896ebbd0c5d92d462777e759e78bb083/zensical-0.0.24-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3c6b39659156394ff805b4831dac108c839483d9efa4c9b901eaa913efee1ac7", size = 12854318, upload-time = "2026-02-26T09:43:35.632Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/28/0ddab6c1237e3625e7763ff666806f31e5760bb36d18624135a6bb6e8643/zensical-0.0.24-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9eef82865a18b3ca4c3cd13e245dff09a865d1da3c861e2fc86eaa9253a90f02", size = 12818270, upload-time = "2026-02-26T09:43:37.749Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/93/d2cef3705d4434896feadffb5b3e44744ef9f1204bc41202c1b84a4eeef6/zensical-0.0.24-cp310-abi3-win32.whl", hash = "sha256:f4d0ff47d505c786a26c9332317aa3e9ad58d1382f55212a10dc5bafcca97864", size = 11857695, upload-time = "2026-02-26T09:43:39.906Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/26/9707587c0f6044dd1e1cc5bc3b9fa5fed81ce6c7bcdb09c21a9795e802d9/zensical-0.0.24-cp310-abi3-win_amd64.whl", hash = "sha256:e00a62cf04526dbed665e989b8f448eb976247f077a76dfdd84699ace4aa3ac3", size = 12057762, upload-time = "2026-02-26T09:43:42.627Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/aa/b8201af30e376a67566f044a1c56210edac5ae923fd986a836d2cf593c9c/zensical-0.0.24-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d390c5453a5541ca35d4f9e1796df942b6612c546e3153dd928236d3b758409a", size = 12263407 },
+    { url = "https://files.pythonhosted.org/packages/78/8e/3d910214471ade604fd39b080db3696864acc23678b5b4b8475c7dbfd2ce/zensical-0.0.24-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:81ac072869cf4d280853765b2bfb688653da0dfb9408f3ab15aca96455ab8223", size = 12142610 },
+    { url = "https://files.pythonhosted.org/packages/cf/d7/eb0983640aa0419ddf670298cfbcf8b75629b6484925429b857851e00784/zensical-0.0.24-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5eb1dfa84cae8e960bfa2c6851d2bc8e9710c4c4c683bd3aaf23185f646ae46", size = 12508380 },
+    { url = "https://files.pythonhosted.org/packages/a3/04/4405b9e6f937a75db19f0d875798a7eb70817d6a3bec2a2d289a2d5e8aea/zensical-0.0.24-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:57d7c9e589da99c1879a1c703e67c85eaa6be4661cdc6ce6534f7bb3575983f4", size = 12440807 },
+    { url = "https://files.pythonhosted.org/packages/12/dc/a7ca2a4224b3072a2c2998b6611ad7fd4f8f131ceae7aa23238d97d26e22/zensical-0.0.24-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:42fcc121c3095734b078a95a0dae4d4924fb8fbf16bf730456146ad6cab48ad0", size = 12782727 },
+    { url = "https://files.pythonhosted.org/packages/42/37/22f1727da356ed3fcbd31f68d4a477f15c232997c87e270cfffb927459ac/zensical-0.0.24-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:832d4a2a051b9f49561031a2986ace502326f82d9a401ddf125530d30025fdd4", size = 12547616 },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/c75ff111b8e12157901d00752beef9d691dbb5a034b6a77359972262416a/zensical-0.0.24-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e5fea3bb61238dba9f930f52669db67b0c26be98e1c8386a05eb2b1e3cb875dc", size = 12684883 },
+    { url = "https://files.pythonhosted.org/packages/b9/92/4f6ea066382e3d068d3cadbed99e9a71af25e46c84a403e0f747960472a2/zensical-0.0.24-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:75eef0428eec2958590633fdc82dc2a58af124879e29573aa7e153b662978073", size = 12713825 },
+    { url = "https://files.pythonhosted.org/packages/bc/fb/bf735b19bce0034b1f3b8e1c50b2896ebbd0c5d92d462777e759e78bb083/zensical-0.0.24-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3c6b39659156394ff805b4831dac108c839483d9efa4c9b901eaa913efee1ac7", size = 12854318 },
+    { url = "https://files.pythonhosted.org/packages/7e/28/0ddab6c1237e3625e7763ff666806f31e5760bb36d18624135a6bb6e8643/zensical-0.0.24-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9eef82865a18b3ca4c3cd13e245dff09a865d1da3c861e2fc86eaa9253a90f02", size = 12818270 },
+    { url = "https://files.pythonhosted.org/packages/2a/93/d2cef3705d4434896feadffb5b3e44744ef9f1204bc41202c1b84a4eeef6/zensical-0.0.24-cp310-abi3-win32.whl", hash = "sha256:f4d0ff47d505c786a26c9332317aa3e9ad58d1382f55212a10dc5bafcca97864", size = 11857695 },
+    { url = "https://files.pythonhosted.org/packages/f1/26/9707587c0f6044dd1e1cc5bc3b9fa5fed81ce6c7bcdb09c21a9795e802d9/zensical-0.0.24-cp310-abi3-win_amd64.whl", hash = "sha256:e00a62cf04526dbed665e989b8f448eb976247f077a76dfdd84699ace4aa3ac3", size = 12057762 },
 ]


### PR DESCRIPTION
Reverse-engineers Apple's CRArchive protobuf format (NSKeyedArchiver over protobuf) to extract call recording transcripts from the `ZMERGEABLEDATA1` column in `NoteStore.sqlite`.

## Key changes

### CRArchive decoder (`recording_utils.py`)
- Schema-driven protobuf parser for CRArchive structure
- Walks `ICTTTranscriptSegment` objects with speaker/text/timestamp resolved through `registerLatest → NSString/NSNumber` chains
- Timestamp-based sorting (fixed64 doubleValue) for correct reading order
- Speaker labels from root `ICTTAudioRecording` (`callLocalSpeakerHandle` / `callRemoteSpeakerHandle`)
- Contact name resolution via macOS Contacts AppleScript (both +27 and 0 formats, cached)

### Regression tests (`test_transcript_parsing.py`)
9 structural tests using a local-only CRDT blob fixture (gitignored) validating:
- Speaker turn alternation and formatting
- Multi-word sentence merging
- No binary garbage or float artifacts
- Contact name substitution
- Tests skip gracefully in CI when fixture is absent

## Checklist
- [x] I have read CONTRIBUTING.md and this PR follows the guidelines
- [x] A human has reviewed the entire diff of this PR, every line of code
- [x] A human understands the changes and can explain why this approach is correct
- [x] This PR doesn't have AI-generated boilerplate or co-author lines
- [ ] This PR was authored and submitted by an AI agent without human review"