### PR TITLE
Improve HTML → Markdown conversion roundtrips

### DIFF
--- a/src/memo_helpers/md_converter.py
+++ b/src/memo_helpers/md_converter.py
@@ -34,10 +34,61 @@ def restore_images(html, image_map):
     return html
 
 
+def normalize_notes_heading_blocks(html):
+    """Promote Apple Notes heading-like blocks into semantic headings.
+
+    Apple Notes may export headings as styled <div><b>...</b></div> blocks rather
+    than <h1>/<h2>/<h3>. Convert only the narrow patterns we understand before
+    handing HTML to html2text.
+    """
+
+    heading_patterns = (
+        (
+            re.compile(
+                r"<div>\s*<b>\s*<span[^>]*style=\"[^\"]*font-size:\s*24px[^\"]*\"[^>]*>"
+                r"\s*(.*?)\s*</span>\s*</b>\s*</div>",
+                re.IGNORECASE | re.DOTALL,
+            ),
+            "h1",
+        ),
+        (
+            re.compile(
+                r"<div>\s*<b>\s*<span[^>]*style=\"[^\"]*font-size:\s*18px[^\"]*\"[^>]*>"
+                r"\s*(.*?)\s*</span>\s*</b>\s*</div>",
+                re.IGNORECASE | re.DOTALL,
+            ),
+            "h2",
+        ),
+    )
+
+    normalized_html = html
+    for pattern, heading_tag in heading_patterns:
+        normalized_html = pattern.sub(
+            lambda match: f"<{heading_tag}>{match.group(1).strip()}</{heading_tag}>",
+            normalized_html,
+        )
+
+    h3_pattern = re.compile(
+        r"<div>\s*<b>\s*([^<]+?)\s*</b>\s*</div>",
+        re.IGNORECASE | re.DOTALL,
+    )
+
+    def replace_h3(match):
+        text = match.group(1).strip()
+        if re.search(r"[.!?]", text):
+            return match.group(0)
+        return f"<h3>{text}</h3>"
+
+    normalized_html = h3_pattern.sub(replace_h3, normalized_html)
+
+    return normalized_html
+
+
 def md_converter(id_search_result):
     original_html = id_search_result.stdout.strip()
 
     cleaned_html, image_map = extract_images(original_html)
+    cleaned_html = normalize_notes_heading_blocks(cleaned_html)
 
     text_maker = html2text.HTML2Text()
     text_maker.images_to_alt = True

--- a/src/memo_helpers/md_converter.py
+++ b/src/memo_helpers/md_converter.py
@@ -41,47 +41,95 @@ def normalize_notes_heading_blocks(html):
     than <h1>/<h2>/<h3>. Convert only the narrow patterns we understand before
     handing HTML to html2text.
     """
-
-    heading_patterns = (
-        (
-            re.compile(
-                r"<div>\s*<b>\s*<span[^>]*style=\"[^\"]*font-size:\s*24px[^\"]*\"[^>]*>"
-                r"\s*(.*?)\s*</span>\s*</b>\s*</div>",
-                re.IGNORECASE | re.DOTALL,
-            ),
-            "h1",
-        ),
-        (
-            re.compile(
-                r"<div>\s*<b>\s*<span[^>]*style=\"[^\"]*font-size:\s*18px[^\"]*\"[^>]*>"
-                r"\s*(.*?)\s*</span>\s*</b>\s*</div>",
-                re.IGNORECASE | re.DOTALL,
-            ),
-            "h2",
-        ),
-    )
-
-    normalized_html = html
-    for pattern, heading_tag in heading_patterns:
-        normalized_html = pattern.sub(
-            lambda match: f"<{heading_tag}>{match.group(1).strip()}</{heading_tag}>",
-            normalized_html,
-        )
-
-    h3_pattern = re.compile(
-        r"<div>\s*<b>\s*([^<]+?)\s*</b>\s*</div>",
+    heading_block_pattern = re.compile(
+        r"<div>\s*<b>\s*"
+        r"(?:(?:<span[^>]*style=\"[^\"]*font-size:\s*(?P<size>24|18)px[^\"]*\"[^>]*>"
+        r"(?P<span_text>.*?)</span>)|(?P<plain_text>[^<]*?))"
+        r"\s*</b>\s*(?:<br\s*/?>\s*)?</div>",
         re.IGNORECASE | re.DOTALL,
     )
 
-    def replace_h3(match):
-        text = match.group(1).strip()
+    def normalize_heading_text(text):
+        text = re.sub(r"<br\s*/?>", " ", text, flags=re.IGNORECASE)
+        text = re.sub(r"&nbsp;|&#160;", " ", text, flags=re.IGNORECASE)
+        text = re.sub(r"<[^>]+>", "", text)
+        return re.sub(r"\s+", " ", text).strip()
+
+    def classify_heading_block(match):
+        size = match.group("size")
+        if size == "24":
+            return "h1", normalize_heading_text(match.group("span_text"))
+        if size == "18":
+            return "h2", normalize_heading_text(match.group("span_text"))
+
+        text = normalize_heading_text(match.group("plain_text") or "")
         if re.search(r"[.!?]", text):
-            return match.group(0)
-        return f"<h3>{text}</h3>"
+            return None
+        return "h3", text
 
-    normalized_html = h3_pattern.sub(replace_h3, normalized_html)
+    output = []
+    pending_tag = None
+    pending_parts = []
+    cursor = 0
 
-    return normalized_html
+    def flush_pending():
+        nonlocal pending_tag, pending_parts
+        if pending_tag and pending_parts:
+            output.append(f"<{pending_tag}>{' '.join(pending_parts)}</{pending_tag}>")
+        pending_tag = None
+        pending_parts = []
+
+    for match in heading_block_pattern.finditer(html):
+        interstitial = html[cursor : match.start()]
+        heading = classify_heading_block(match)
+
+        if heading is None:
+            flush_pending()
+            output.append(interstitial)
+            output.append(match.group(0))
+            cursor = match.end()
+            continue
+
+        heading_tag, heading_text = heading
+        if pending_tag:
+            if interstitial.strip() == "" and heading_tag == pending_tag:
+                if heading_text:
+                    pending_parts.append(heading_text)
+                cursor = match.end()
+                continue
+
+            flush_pending()
+            output.append(interstitial)
+        else:
+            output.append(interstitial)
+
+        if heading_text:
+            pending_tag = heading_tag
+            pending_parts = [heading_text]
+
+        cursor = match.end()
+
+    flush_pending()
+    output.append(html[cursor:])
+    return "".join(output)
+
+
+def normalize_unordered_list_indentation(markdown):
+    """Undo html2text's extra indent on unordered list items.
+
+    The html2text version used here emits unordered list bullets one level too
+    deep for Notes-style list HTML after the first item. Remove a single
+    indentation level while leaving ordered lists and non-list lines untouched.
+    """
+
+    normalized_lines = []
+    for line in markdown.splitlines():
+        if re.match(r"^  +[*+-]\s", line):
+            normalized_lines.append(line[2:])
+        else:
+            normalized_lines.append(line)
+
+    return "\n".join(normalized_lines)
 
 
 def md_converter(id_search_result):
@@ -94,4 +142,5 @@ def md_converter(id_search_result):
     text_maker.images_to_alt = True
     text_maker.body_width = 0
     original_md = text_maker.handle(cleaned_html).strip()
+    original_md = normalize_unordered_list_indentation(original_md)
     return [original_md, original_html, image_map]

--- a/tests/test_md_converter_notes_headings.py
+++ b/tests/test_md_converter_notes_headings.py
@@ -58,11 +58,137 @@ def test_notes_heading_like_blocks_map_to_headings_in_mixed_content():
     )
 
 
+def test_notes_heading_like_block_with_trailing_br_maps_to_heading():
+    html = '<div><b><span style="font-size: 24px">2026 North Side</span></b><br></div>'
+
+    markdown, original_html, image_map = _markdown_from_notes_html(html)
+
+    assert markdown == "# 2026 North Side"
+    assert original_html == html
+    assert image_map == {}
+
+
+def test_blank_heading_fragments_are_ignored_in_notes_body():
+    html = (
+        '<div><b><span style="font-size: 24px">Title</span></b></div>\n'
+        '<div><b><span style="font-size: 24px"> </span></b><br></div>\n'
+        "<div>Body</div>"
+    )
+
+    markdown, original_html, image_map = _markdown_from_notes_html(html)
+
+    assert markdown == "# Title\n\nBody"
+    assert original_html == html
+    assert image_map == {}
+
+
+def test_adjacent_same_level_heading_fragments_are_merged_sensibly():
+    html = (
+        '<div><b><span style="font-size: 24px">Air</span></b></div>\n'
+        '<div><b><span style="font-size: 24px"> </span></b></div>\n'
+        '<div><b><span style="font-size: 24px">conditioning</span></b><br></div>\n'
+        "<div>Body</div>"
+    )
+
+    markdown, original_html, image_map = _markdown_from_notes_html(html)
+
+    assert markdown == "# Air conditioning\n\nBody"
+    assert original_html == html
+    assert image_map == {}
+
+
 def test_plain_bold_block_does_not_become_a_heading():
     html = "<div><b>Bold sentence with punctuation.</b></div>"
 
     markdown, original_html, image_map = _markdown_from_notes_html(html)
 
     assert markdown == "**Bold sentence with punctuation.**"
+    assert original_html == html
+    assert image_map == {}
+
+
+def test_blank_heading_fragments_do_not_emit_stray_bold_spacers():
+    html = (
+        '<div><b><span style="font-size: 18px">Preferences</span></b></div>\n'
+        '<div><b><span style="font-size: 18px"> </span></b></div>\n'
+        "<div>Bring extra blankets</div>"
+    )
+
+    markdown, _, _ = _markdown_from_notes_html(html)
+
+    assert markdown == "## Preferences\n\nBring extra blankets"
+    assert "****" not in markdown
+
+
+@pytest.mark.parametrize(
+    ("html", "expected_markdown"),
+    [
+        (
+            "<ul><li>First</li><li>Second</li></ul>",
+            "* First\n* Second",
+        ),
+        (
+            '<ul class="Apple-dash-list"><li>First</li><li>Second</li></ul>',
+            "* First\n* Second",
+        ),
+        (
+            "<ul><li>Parent<ul><li>Child</li></ul></li><li>Sibling</li></ul>",
+            "* Parent\n  * Child\n* Sibling",
+        ),
+    ],
+    ids=["regular-ul", "apple-dash-list", "nested-ul"],
+)
+def test_notes_unordered_lists_preserve_readable_markdown_structure(
+    html, expected_markdown
+):
+    markdown, original_html, image_map = _markdown_from_notes_html(html)
+
+    assert markdown == expected_markdown
+    assert original_html == html
+    assert image_map == {}
+
+
+@pytest.mark.parametrize(
+    ("html", "expected_markdown"),
+    [
+        ("<div>https://example.com/path?q=1</div>", "https://example.com/path?q=1"),
+        (
+            '<div><a href="https://example.com/path?q=1">Example</a></div>',
+            "[Example](https://example.com/path?q=1)",
+        ),
+        (
+            '<div><a href="https://example.com">https://example.com</a></div>',
+            "<https://example.com>",
+        ),
+    ],
+    ids=["plain-url-line", "anchor-link", "autolink"],
+)
+def test_notes_links_are_preserved_when_html_has_plain_urls_or_anchors(
+    html, expected_markdown
+):
+    markdown, original_html, image_map = _markdown_from_notes_html(html)
+
+    assert markdown == expected_markdown
+    assert original_html == html
+    assert image_map == {}
+
+
+@pytest.mark.parametrize(
+    ("html", "expected_markdown"),
+    [
+        ("<div><b>Label:</b> value</div>", "**Label:** value"),
+        (
+            "<ul><li><b>Label:</b> value</li><li>Next</li></ul>",
+            "* **Label:** value\n* Next",
+        ),
+    ],
+    ids=["paragraph-bold-label", "list-bold-label"],
+)
+def test_notes_bold_labels_are_preserved_in_paragraphs_and_lists(
+    html, expected_markdown
+):
+    markdown, original_html, image_map = _markdown_from_notes_html(html)
+
+    assert markdown == expected_markdown
     assert original_html == html
     assert image_map == {}

--- a/tests/test_md_converter_notes_headings.py
+++ b/tests/test_md_converter_notes_headings.py
@@ -11,50 +11,58 @@ def _markdown_from_notes_html(html):
     return markdown, original_html, image_map
 
 
-# Characterization tests for a suspected heading-collapse bug.
 # Apple Notes can export headings as styled div/b/span blocks instead of <h1>/<h2>/<h3>.
-# The current converter path appears to collapse those blocks to bold Markdown rather than
-# heading syntax. These assertions document the current behavior without endorsing it.
+# The converter normalizes those Notes-specific blocks before generic html2text handling.
 @pytest.mark.parametrize(
     ("html", "expected_markdown"),
     [
         (
             '<div><b><span style="font-size: 24px">Title</span></b></div>',
-            "**Title**",
+            "# Title",
         ),
         (
             '<div><b><span style="font-size: 18px">Section One</span></b></div>',
-            "**Section One**",
+            "## Section One",
         ),
-        ("<div><b>Subsection One</b></div>", "**Subsection One**"),
+        ("<div><b>Subsection One</b></div>", "### Subsection One"),
     ],
     ids=["notes-h1-like", "notes-h2-like", "notes-h3-like"],
 )
-def test_notes_heading_like_html_currently_collapses_to_bold(
-    html, expected_markdown
-):
+def test_notes_heading_like_html_maps_to_headings(html, expected_markdown):
     markdown, original_html, image_map = _markdown_from_notes_html(html)
 
     assert markdown == expected_markdown
     assert original_html == html
     assert image_map == {}
-    assert "#" not in markdown
 
 
-def test_notes_heading_like_blocks_stay_bold_in_mixed_content():
+def test_notes_heading_like_blocks_map_to_headings_in_mixed_content():
     html = (
         '<div><b><span style="font-size: 24px">Title</span></b></div>\n'
         "<div>Body paragraph</div>\n"
         '<div><b><span style="font-size: 18px">Section One</span></b></div>\n'
-        "<div><b>Subsection One</b></div>"
+        "<div>Section body</div>\n"
+        "<div><b>Subsection One</b></div>\n"
+        "<div>Subsection body</div>"
     )
 
     markdown, _, _ = _markdown_from_notes_html(html)
 
-    assert "**Title**" in markdown
-    assert "Body paragraph" in markdown
-    assert "**Section One**" in markdown
-    assert "**Subsection One**" in markdown
-    assert "# Title" not in markdown
-    assert "## Section One" not in markdown
-    assert "### Subsection One" not in markdown
+    assert markdown == (
+        "# Title\n\n"
+        "Body paragraph\n\n"
+        "## Section One\n\n"
+        "Section body\n\n"
+        "### Subsection One\n\n"
+        "Subsection body"
+    )
+
+
+def test_plain_bold_block_does_not_become_a_heading():
+    html = "<div><b>Bold sentence with punctuation.</b></div>"
+
+    markdown, original_html, image_map = _markdown_from_notes_html(html)
+
+    assert markdown == "**Bold sentence with punctuation.**"
+    assert original_html == html
+    assert image_map == {}

--- a/tests/test_md_converter_notes_headings.py
+++ b/tests/test_md_converter_notes_headings.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+
+import pytest
+
+from memo_helpers.md_converter import md_converter
+
+
+def _markdown_from_notes_html(html):
+    """Run the existing Notes HTML -> Markdown path used by the CLI."""
+    markdown, original_html, image_map = md_converter(SimpleNamespace(stdout=html))
+    return markdown, original_html, image_map
+
+
+# Characterization tests for a suspected heading-collapse bug.
+# Apple Notes can export headings as styled div/b/span blocks instead of <h1>/<h2>/<h3>.
+# The current converter path appears to collapse those blocks to bold Markdown rather than
+# heading syntax. These assertions document the current behavior without endorsing it.
+@pytest.mark.parametrize(
+    ("html", "expected_markdown"),
+    [
+        (
+            '<div><b><span style="font-size: 24px">Title</span></b></div>',
+            "**Title**",
+        ),
+        (
+            '<div><b><span style="font-size: 18px">Section One</span></b></div>',
+            "**Section One**",
+        ),
+        ("<div><b>Subsection One</b></div>", "**Subsection One**"),
+    ],
+    ids=["notes-h1-like", "notes-h2-like", "notes-h3-like"],
+)
+def test_notes_heading_like_html_currently_collapses_to_bold(
+    html, expected_markdown
+):
+    markdown, original_html, image_map = _markdown_from_notes_html(html)
+
+    assert markdown == expected_markdown
+    assert original_html == html
+    assert image_map == {}
+    assert "#" not in markdown
+
+
+def test_notes_heading_like_blocks_stay_bold_in_mixed_content():
+    html = (
+        '<div><b><span style="font-size: 24px">Title</span></b></div>\n'
+        "<div>Body paragraph</div>\n"
+        '<div><b><span style="font-size: 18px">Section One</span></b></div>\n'
+        "<div><b>Subsection One</b></div>"
+    )
+
+    markdown, _, _ = _markdown_from_notes_html(html)
+
+    assert "**Title**" in markdown
+    assert "Body paragraph" in markdown
+    assert "**Section One**" in markdown
+    assert "**Subsection One**" in markdown
+    assert "# Title" not in markdown
+    assert "## Section One" not in markdown
+    assert "### Subsection One" not in markdown


### PR DESCRIPTION
As discussed in #34 this *is* an AI-generated set of code, so I am not attesting otherwise. Sharing for exploration purposes not because I intend for this to be accepted.

I read CONTRIBUTING.md and this does *not* comply. This was made using OpenClaw and Codex.


- recognizes Apple Notes heading-like export blocks and maps them to semantic Markdown headings
- font-size: 24px → #
- font-size: 18px → ##
- plain bold heading-like blocks without sentence punctuation → ###
- merges adjacent same-level heading fragments when Notes splits a heading across multiple blocks
- ignores blank heading fragments so they don't produce stray Markdown noise
- normalizes unordered-list indentation after html2text so Notes-style list HTML renders as expected

The test suite adds characterization coverage for:
- heading-like Notes HTML
- mixed heading/body content
- trailing <br> heading blocks
- blank heading fragments
- adjacent fragmented headings
- punctuation-bearing bold blocks that should stay bold, not become headings
- unordered and nested unordered lists

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR follows the guidelines
- [ ] A human has reviewed the **entire diff** of this PR, every line of code
- [ ] A human understands the changes and can explain why this approach is correct
- [ ] This PR doesn't have AI-generated boilerplate or co-author lines
- [X] This PR was authored and submitted by an AI agent without human review
