### PR TITLE
feat: support nested folders with duplicate names

### DIFF
--- a/src/memo/memo.py
+++ b/src/memo/memo.py
@@ -19,6 +19,11 @@ from memo_helpers.cache_memo import clear_cache
 from memo_helpers.export_memo import export_memo
 from memo_helpers.id_search_memo import id_search_memo
 from memo_helpers.md_converter import md_converter
+from memo_helpers.folder_memo import (
+    folder_paths_from_tree,
+    note_belongs_to_folder,
+    resolve_folder_path,
+)
 
 # TODO: Check if notes can be imported.
 # TODO: Check if its possible to fetch .localized names from the folders.
@@ -124,10 +129,19 @@ def notes(
     notes_info = get_note()
     note_map = notes_info[0]
     notes_list = notes_info[1]
-    notes_list_filter = [
-        note for note in enumerate(notes_list, start=1) if folder in note[1]
-    ]
     folders = notes_folders()
+    folder_paths = folder_paths_from_tree(folders)
+    resolved_folder = resolve_folder_path(folder, folder_paths) if folder else ""
+    notes_list_filter = [
+        note
+        for note in enumerate(notes_list, start=1)
+        if note_belongs_to_folder(note[1], resolved_folder)
+    ]
+
+    if folder and not resolved_folder and not flist and not search and not remove:
+        click.echo("\nThe folder does not exists.")
+        click.echo("\nUse 'memo notes -fl' to see your folders")
+        return
 
     if view is not None:
         if view not in note_map:
@@ -144,13 +158,14 @@ def notes(
 
     if not flist and not search and not remove and not export:
         click.secho("\nFetching notes...", fg="yellow")
-        if folder not in folders:
-            click.echo("\nThe folder does not exists.")
-            click.echo("\nUse 'memo notes -fl' to see your folders")
-        elif not notes_list_filter:
+        if not notes_list_filter:
             click.echo("\nNo notes found.")
         else:
-            title = f"Your Notes in folder {folder}:" if folder else "All your notes:"
+            title = (
+                f"Your Notes in folder {resolved_folder}:"
+                if resolved_folder
+                else "All your notes:"
+            )
             click.echo(f"\n{title}\n")
             for note in notes_list_filter:
                 click.echo(f"{note[0]}. {note[1]}")
@@ -160,7 +175,7 @@ def notes(
         edit_note(note_id)
         clear_cache()
     if add:
-        add_note(folder)
+        add_note(resolved_folder)
         clear_cache()
     if move:
         note_id = pick_note(note_map, notes_list_filter, "move")
@@ -196,11 +211,11 @@ def notes(
     if export:
         confirmation_message = "\nAre you sure you want to export your notes to HTML?"
         default_path = os.path.expanduser("~/Desktop/notes/")
-        if folder:
-            confirmation_message = f"\nAre you sure you want to export your notes in the folder '{folder}' to HTML?"
+        if resolved_folder:
+            confirmation_message = f"\nAre you sure you want to export your notes in the folder '{resolved_folder}' to HTML?"
             if click.confirm(confirmation_message):
                 export_path_str = export_path(default_path)
-                export_memo(export_path_str, folder)
+                export_memo(export_path_str, resolved_folder)
         else:
             if click.confirm(confirmation_message):
                 export_path_str = export_path(default_path)

--- a/src/memo_helpers/add_memo.py
+++ b/src/memo_helpers/add_memo.py
@@ -4,6 +4,7 @@ import tempfile
 import mistune
 import os
 from datetime import datetime
+from memo_helpers.folder_memo import folder_lookup_script
 
 
 def add_note(folder_name):
@@ -26,7 +27,7 @@ def add_note(folder_name):
 
     script = f"""
         tell application "Notes"
-            set targetFolder to first folder whose name is "{folder_name}"
+            {folder_lookup_script(folder_name)}
             tell targetFolder
                 make new note with properties {{body:"{note_html}"}}
             end tell

--- a/src/memo_helpers/cache_memo.py
+++ b/src/memo_helpers/cache_memo.py
@@ -5,12 +5,14 @@ import time
 CACHE_DIR = os.path.expanduser("~/.cache/memo")
 CACHE_FILE = os.path.join(CACHE_DIR, "notes_cache.json")
 DEFAULT_TTL = 300  # 5 minutes
+CACHE_VERSION = 2
 
 
 def save_cache(note_map, notes_list):
     os.makedirs(CACHE_DIR, exist_ok=True)
     serializable_map = {str(k): list(v) for k, v in note_map.items()}
     data = {
+        "version": CACHE_VERSION,
         "timestamp": time.time(),
         "note_map": serializable_map,
         "notes_list": notes_list,
@@ -26,6 +28,8 @@ def load_cache(ttl=DEFAULT_TTL):
         with open(CACHE_FILE, "r", encoding="utf-8") as f:
             data = json.load(f)
     except (json.JSONDecodeError, KeyError):
+        return None
+    if data.get("version") != CACHE_VERSION:
         return None
     if time.time() - data["timestamp"] > ttl:
         return None

--- a/src/memo_helpers/choice_memo.py
+++ b/src/memo_helpers/choice_memo.py
@@ -9,7 +9,8 @@ def pick_note(note_map, notes_list, action):
     choice = click.prompt(
         f"\nEnter the number of the note you want to {action}", type=int
     )
-    if 1 <= choice <= len(notes_list):
+    available_choices = {note_number for note_number, _ in notes_list}
+    if choice in available_choices:
         note_data = note_map.get(choice)
         if note_data is None:
             click.echo("Invalid selection.")

--- a/src/memo_helpers/export_memo.py
+++ b/src/memo_helpers/export_memo.py
@@ -3,21 +3,13 @@ import os
 import click
 import html2text
 import chardet
+from memo_helpers.folder_memo import folder_lookup_script
 
 
 def export_memo(path: str, notes_folder: str | None = None):
     if notes_folder:
         folder_filter = f"""
-        set targetFolder to missing value
-        repeat with f in folders of default account
-            if name of f is "{notes_folder}" then
-                set targetFolder to f
-                exit repeat
-            end if
-        end repeat
-        if targetFolder is missing value then
-            error "Folder '{notes_folder}' not found"
-        end if
+        {folder_lookup_script(notes_folder)}
         set notesToExport to notes of targetFolder
         """
     else:

--- a/src/memo_helpers/folder_memo.py
+++ b/src/memo_helpers/folder_memo.py
@@ -1,0 +1,142 @@
+PATH_SEPARATOR = "/"
+
+
+def normalize_folder_path(folder_path: str | None) -> str:
+    if not folder_path:
+        return ""
+    return PATH_SEPARATOR.join(
+        part.strip() for part in folder_path.split(PATH_SEPARATOR) if part.strip()
+    )
+
+
+def folder_paths_from_tree(folders_tree: str) -> list[str]:
+    paths_by_level: dict[int, str] = {}
+    folder_paths = []
+
+    for line in folders_tree.splitlines():
+        if not line.strip():
+            continue
+
+        indent = len(line) - len(line.lstrip(" "))
+        level = indent // 2
+        name = line.strip()
+        parent_path = paths_by_level.get(level - 1, "")
+        folder_path = normalize_folder_path(
+            f"{parent_path}{PATH_SEPARATOR}{name}" if parent_path else name
+        )
+
+        paths_by_level[level] = folder_path
+        for deeper_level in [key for key in paths_by_level if key > level]:
+            del paths_by_level[deeper_level]
+
+        folder_paths.append(folder_path)
+
+    return folder_paths
+
+
+def resolve_folder_path(folder_path: str, known_folder_paths: list[str]) -> str:
+    requested_path = normalize_folder_path(folder_path)
+    normalized_paths = [normalize_folder_path(path) for path in known_folder_paths]
+
+    if requested_path in normalized_paths:
+        return requested_path
+
+    matching_basenames = [
+        path
+        for path in normalized_paths
+        if path.split(PATH_SEPARATOR)[-1] == requested_path
+    ]
+    if len(matching_basenames) == 1:
+        return matching_basenames[0]
+
+    return ""
+
+
+def note_belongs_to_folder(note_title: str, folder_path: str) -> bool:
+    normalized_folder = normalize_folder_path(folder_path)
+    if not normalized_folder:
+        return True
+
+    folder_prefix = f"{normalized_folder} - "
+    if note_title.startswith(folder_prefix):
+        return True
+
+    # Older cache entries stored only the leaf folder name. Only allow this
+    # fallback for unambiguous single-segment folder filters.
+    if PATH_SEPARATOR in normalized_folder:
+        return False
+
+    folder_name = normalized_folder.split(PATH_SEPARATOR)[-1]
+    return note_title.startswith(f"{folder_name} - ")
+
+
+def applescript_string(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def applescript_list(values: list[str]) -> str:
+    return "{" + ", ".join(applescript_string(value) for value in values) + "}"
+
+
+def folder_lookup_script(folder_path: str, variable_name: str = "targetFolder") -> str:
+    normalized_path = normalize_folder_path(folder_path)
+    parts = normalized_path.split(PATH_SEPARATOR)
+    if not parts or parts == [""]:
+        raise ValueError("folder_path must not be empty")
+
+    return f"""
+        set folderPathParts to {applescript_list(parts)}
+        set {variable_name} to missing value
+        repeat with acc in accounts
+            try
+                set candidateFolder to folder (item 1 of folderPathParts) of acc
+                if (count of folderPathParts) > 1 then
+                    repeat with folderIndex from 2 to count of folderPathParts
+                        set candidateFolder to folder (item folderIndex of folderPathParts) of candidateFolder
+                    end repeat
+                end if
+                set {variable_name} to candidateFolder
+                exit repeat
+            end try
+        end repeat
+        if {variable_name} is missing value and (count of folderPathParts) is 1 then
+            try
+                set {variable_name} to first folder whose name is (item 1 of folderPathParts)
+            end try
+        end if
+        if {variable_name} is missing value then
+            error {applescript_string(f"Folder {normalized_path} not found")}
+        end if
+    """
+
+
+def folder_path_handler_script() -> str:
+    return """
+    on folderPath(folderId)
+        tell application "Notes"
+            set theFolder to first folder whose id is folderId
+            set pathParts to {name of theFolder as text}
+            try
+                set currentContainer to container of theFolder
+                repeat
+                    try
+                        if (class of currentContainer as text) is "folder" then
+                            set beginning of pathParts to name of currentContainer as text
+                            set currentContainer to container of currentContainer
+                        else
+                            exit repeat
+                        end if
+                    on error
+                        exit repeat
+                    end try
+                end repeat
+            end try
+            set previousDelimiters to AppleScript's text item delimiters
+            set AppleScript's text item delimiters to "/"
+            set folderPathValue to pathParts as text
+            set AppleScript's text item delimiters to previousDelimiters
+            return folderPathValue
+        end tell
+    end folderPath
+    """

--- a/src/memo_helpers/get_memo.py
+++ b/src/memo_helpers/get_memo.py
@@ -2,6 +2,7 @@ import subprocess
 import click
 import datetime
 from memo_helpers.cache_memo import save_cache, load_cache
+from memo_helpers.folder_memo import folder_path_handler_script
 
 
 def get_note():
@@ -9,20 +10,23 @@ def get_note():
     if cached:
         return list(cached)
 
-    script = """
+    script = (
+        folder_path_handler_script()
+        + """
     set deletedTranslations to {"Recently Deleted", "Nylig slettet", "Senast raderade", "Senest slettet", "Zuletzt gelöscht", "Supprimés récemment", "Eliminados recientemente", "Eliminati di recente", "Recent verwijderd", "Ostatnio usunięte", "Недавно удалённые", "Apagados recentemente", "Apagadas recentemente", "最近删除", "最近刪除", "最近削除した項目", "최근 삭제된 항목", "Son Silinenler", "Äskettäin poistetut", "Nedávno smazané", "Πρόσφατα διαγραμμένα", "Nemrég töröltek", "Șterse recent", "Nedávno vymazané", "เพิ่งลบ", "Đã xóa gần đây", "Нещодавно видалені"}
 
     tell application "Notes"
         set notesList to {}
-        repeat with eachFolder in folders
+        repeat with eachFolder in every folder
             set folderName to name of eachFolder
+            set folderPathName to my folderPath(id of eachFolder)
             if folderName is not in deletedTranslations then
                 set folderNotes to notes of eachFolder
                 if (count of folderNotes) > 0 then
                     set noteIDs to id of every note of eachFolder
                     set noteNames to name of every note of eachFolder
                     repeat with i from 1 to count of noteIDs
-                        set end of notesList to (item i of noteIDs) & "|" & folderName & " - " & (item i of noteNames)
+                        set end of notesList to (item i of noteIDs) & "|" & folderPathName & " - " & (item i of noteNames)
                     end repeat
                 end if
             end if
@@ -33,6 +37,7 @@ def get_note():
         return output
     end tell
     """
+    )
 
     result = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
     notes_list = [

--- a/tests/folder_memo_test.py
+++ b/tests/folder_memo_test.py
@@ -1,0 +1,43 @@
+from memo_helpers.folder_memo import (
+    folder_paths_from_tree,
+    note_belongs_to_folder,
+    normalize_folder_path,
+    resolve_folder_path,
+)
+
+DUPLICATE_LEAF_FOLDERS = "Alpha\n  Reports\nBeta\n  Reports"
+
+
+def test_normalize_folder_path_strips_and_joins_segments():
+    assert normalize_folder_path(" Alpha / Reports ") == "Alpha/Reports"
+
+
+def test_folder_paths_from_tree_includes_full_nested_paths():
+    paths = folder_paths_from_tree(DUPLICATE_LEAF_FOLDERS)
+    assert paths == ["Alpha", "Alpha/Reports", "Beta", "Beta/Reports"]
+
+
+def test_resolve_folder_path_matches_full_nested_path():
+    paths = folder_paths_from_tree(DUPLICATE_LEAF_FOLDERS)
+    assert resolve_folder_path("Alpha/Reports", paths) == "Alpha/Reports"
+
+
+def test_resolve_folder_path_rejects_ambiguous_leaf_name():
+    paths = folder_paths_from_tree(DUPLICATE_LEAF_FOLDERS)
+    assert resolve_folder_path("Reports", paths) == ""
+
+
+def test_note_belongs_to_folder_matches_full_path_prefix():
+    assert note_belongs_to_folder("Alpha/Reports - Summary note", "Alpha/Reports")
+
+
+def test_note_belongs_to_folder_rejects_other_branch_with_same_leaf():
+    assert not note_belongs_to_folder("Beta/Reports - Summary note", "Alpha/Reports")
+
+
+def test_note_belongs_to_folder_rejects_leaf_only_title_for_nested_filter():
+    assert not note_belongs_to_folder("Reports - Summary note", "Alpha/Reports")
+
+
+def test_note_belongs_to_folder_allows_leaf_fallback_for_single_segment_filter():
+    assert note_belongs_to_folder("Child - Summary note", "Child")

--- a/tests/memo_notes_test.py
+++ b/tests/memo_notes_test.py
@@ -7,6 +7,14 @@ FAKE_NOTE_TITLE = "My Folder - Test Note"
 FAKE_NOTE_MAP = {1: (FAKE_NOTE_ID, FAKE_NOTE_TITLE)}
 FAKE_NOTES_LIST = [FAKE_NOTE_TITLE]
 FAKE_FOLDERS = "My Folder"
+FAKE_NESTED_FOLDER = "Projects/Memo"
+FAKE_NESTED_FOLDERS = "Projects\n  Memo\nArchive"
+FAKE_NESTED_NOTE_TITLE = "Projects/Memo - Nested Note"
+FAKE_PARENT_NOTE_TITLE = "Projects - Parent Note"
+FAKE_ALPHA_REPORTS_NOTE_TITLE = "Alpha/Reports - Summary note"
+FAKE_BETA_REPORTS_NOTE_TITLE = "Beta/Reports - Summary note"
+FAKE_LEAF_ONLY_NOTE_TITLE = "Reports - Summary note"
+FAKE_DUPLICATE_LEAF_FOLDERS = "Alpha\n  Reports\nBeta\n  Reports"
 
 
 @patch("memo.memo.notes_folders")
@@ -38,6 +46,104 @@ def test_notes_folder_not_exists(mock_get_note, mock_notes_folders):
     assert "The folder does not exists." in result.output
 
 
+@patch("memo.memo.notes_folders")
+@patch("memo.memo.get_note")
+def test_notes_folder_supports_subfolder_path(mock_get_note, mock_notes_folders):
+    mock_get_note.return_value = [
+        {
+            1: (FAKE_NOTE_ID, FAKE_NESTED_NOTE_TITLE),
+            2: ("x-coredata://fake-id-456", FAKE_PARENT_NOTE_TITLE),
+        },
+        [FAKE_NESTED_NOTE_TITLE, FAKE_PARENT_NOTE_TITLE],
+    ]
+    mock_notes_folders.return_value = FAKE_NESTED_FOLDERS
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "--folder", FAKE_NESTED_FOLDER])
+    assert result.exit_code == 0
+    assert f"Your Notes in folder {FAKE_NESTED_FOLDER}:" in result.output
+    assert FAKE_NESTED_NOTE_TITLE in result.output
+    assert FAKE_PARENT_NOTE_TITLE not in result.output
+
+
+@patch("memo.memo.notes_folders")
+@patch("memo.memo.get_note")
+def test_notes_folder_resolves_unique_subfolder_name(mock_get_note, mock_notes_folders):
+    mock_get_note.return_value = [
+        {1: (FAKE_NOTE_ID, FAKE_NESTED_NOTE_TITLE)},
+        [FAKE_NESTED_NOTE_TITLE],
+    ]
+    mock_notes_folders.return_value = FAKE_NESTED_FOLDERS
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "--folder", "Memo"])
+    assert result.exit_code == 0
+    assert f"Your Notes in folder {FAKE_NESTED_FOLDER}:" in result.output
+    assert FAKE_NESTED_NOTE_TITLE in result.output
+
+
+@patch("memo.memo.notes_folders")
+@patch("memo.memo.get_note")
+def test_notes_folder_filters_duplicate_leaf_paths_by_full_path(
+    mock_get_note, mock_notes_folders
+):
+    mock_get_note.return_value = [
+        {
+            1: (FAKE_NOTE_ID, FAKE_ALPHA_REPORTS_NOTE_TITLE),
+            2: ("x-coredata://fake-id-456", FAKE_BETA_REPORTS_NOTE_TITLE),
+            3: ("x-coredata://fake-id-789", FAKE_LEAF_ONLY_NOTE_TITLE),
+        },
+        [
+            FAKE_ALPHA_REPORTS_NOTE_TITLE,
+            FAKE_BETA_REPORTS_NOTE_TITLE,
+            FAKE_LEAF_ONLY_NOTE_TITLE,
+        ],
+    ]
+    mock_notes_folders.return_value = FAKE_DUPLICATE_LEAF_FOLDERS
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "--folder", "Alpha/Reports"])
+    assert result.exit_code == 0
+    assert "Your Notes in folder Alpha/Reports:" in result.output
+    assert FAKE_ALPHA_REPORTS_NOTE_TITLE in result.output
+    assert f"2. {FAKE_BETA_REPORTS_NOTE_TITLE}" not in result.output
+    assert f"3. {FAKE_LEAF_ONLY_NOTE_TITLE}" not in result.output
+    assert f"1. {FAKE_LEAF_ONLY_NOTE_TITLE}" not in result.output
+
+
+@patch("memo.memo.notes_folders")
+@patch("memo.memo.get_note")
+def test_notes_folder_rejects_ambiguous_leaf_name(mock_get_note, mock_notes_folders):
+    mock_get_note.return_value = [
+        {
+            1: (FAKE_NOTE_ID, FAKE_ALPHA_REPORTS_NOTE_TITLE),
+            2: ("x-coredata://fake-id-456", FAKE_BETA_REPORTS_NOTE_TITLE),
+        },
+        [FAKE_ALPHA_REPORTS_NOTE_TITLE, FAKE_BETA_REPORTS_NOTE_TITLE],
+    ]
+    mock_notes_folders.return_value = FAKE_DUPLICATE_LEAF_FOLDERS
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "--folder", "Reports"])
+    assert result.exit_code == 0
+    assert "The folder does not exists." in result.output
+
+
+@patch("memo.memo.clear_cache")
+@patch("memo.memo.add_note")
+@patch("memo.memo.notes_folders")
+@patch("memo.memo.get_note")
+def test_notes_add_uses_resolved_subfolder_path(
+    mock_get_note, mock_notes_folders, mock_add_note, mock_clear_cache
+):
+    mock_get_note.return_value = [
+        {1: (FAKE_NOTE_ID, FAKE_NESTED_NOTE_TITLE)},
+        [FAKE_NESTED_NOTE_TITLE],
+    ]
+    mock_notes_folders.return_value = FAKE_NESTED_FOLDERS
+    runner = CliRunner()
+    result = runner.invoke(cli, ["notes", "--folder", "Memo", "--add"])
+    assert result.exit_code == 0
+    mock_add_note.assert_called_once_with(FAKE_NESTED_FOLDER)
+    mock_clear_cache.assert_called_once()
+
+
 def test_notes_add_no_folder():
     runner = CliRunner()
     result = runner.invoke(cli, ["notes", "--add"])
@@ -60,7 +166,11 @@ def test_notes_edit(mock_get_note, mock_notes_folders, mock_edit_note):
     assert "Enter the number of the note you want to edit:" in result.output
 
 
-def test_notes_edit_indexerror():
+@patch("memo.memo.notes_folders")
+@patch("memo.memo.get_note")
+def test_notes_edit_indexerror(mock_get_note, mock_notes_folders):
+    mock_get_note.return_value = [FAKE_NOTE_MAP, FAKE_NOTES_LIST]
+    mock_notes_folders.return_value = FAKE_FOLDERS
     runner = CliRunner()
     result = runner.invoke(cli, ["notes", "--edit"], input="9999")
     assert result.exit_code == 1
@@ -79,13 +189,21 @@ def test_notes_delete(mock_get_note, mock_notes_folders, mock_subprocess):
     assert "Note deleted successfully." in result.output
 
 
-def test_notes_delete_indexerror():
+@patch("memo.memo.notes_folders")
+@patch("memo.memo.get_note")
+def test_notes_delete_indexerror(mock_get_note, mock_notes_folders):
+    mock_get_note.return_value = [FAKE_NOTE_MAP, FAKE_NOTES_LIST]
+    mock_notes_folders.return_value = FAKE_FOLDERS
     runner = CliRunner()
     result = runner.invoke(cli, ["notes", "--delete"], input="9999")
     assert result.exit_code == 1
 
 
-def test_notes_move_indexerror():
+@patch("memo.memo.notes_folders")
+@patch("memo.memo.get_note")
+def test_notes_move_indexerror(mock_get_note, mock_notes_folders):
+    mock_get_note.return_value = [FAKE_NOTE_MAP, FAKE_NOTES_LIST]
+    mock_notes_folders.return_value = FAKE_FOLDERS
     runner = CliRunner()
     result = runner.invoke(cli, ["notes", "--move"], input="9999")
     assert result.exit_code == 1

--- a/uv.lock
+++ b/uv.lock
@@ -155,7 +155,7 @@ wheels = [
 
 [[package]]
 name = "memo"
-version = "0.5.3"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
## Summary

Memo can now access subfolders with non-unique names by resolving full nested folder paths. Folder filtering and relevant actions use the resolved path instead of matching on leaf folder names alone.

## Test plan

```bash
uv run pytest -r w tests/
```

36 passed.